### PR TITLE
feat(onComplete): Adding onComplete callback property for manual form…

### DIFF
--- a/packages/embed-react/src/__snapshots__/storyshots.test.ts.snap
+++ b/packages/embed-react/src/__snapshots__/storyshots.test.ts.snap
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Embed React Default 1`] = `<div />`;
+exports[`Storyshots Embed React Default 1`] = `
+Array [
+  <form />,
+  <div />,
+]
+`;

--- a/packages/embed-react/src/index.stories.tsx
+++ b/packages/embed-react/src/index.stories.tsx
@@ -5,7 +5,7 @@ import {
   select,
   number,
 } from '@storybook/addon-knobs'
-import React from 'react'
+import React, { useRef } from 'react'
 import Gr4vyEmbed from './'
 
 export default {
@@ -26,26 +26,38 @@ const intentOptions = [`capture`, `approve`, `auhtorize`]
 
 const environmentOptions = ['development', 'production', 'staging']
 
-export const Default = () => (
-  <Gr4vyEmbed
-    amount={number(`Amount`, 1299, {}, `Public`)}
-    intent={select(`Intent`, intentOptions, 'capture', `Public`) as any}
-    currency={select(`Currency`, currencyOptions, `USD`, `Public`)}
-    apiHost={text(`API host`, `127.0.0.1:3100`, `Public`)}
-    iframeHost={text(`iFrame host`, `127.0.0.1:8080`, `Public`)}
-    token={text(`JWT token`, `1234567`, `Public`)}
-    showButton={boolean(`Enable submit button`, true, `Public`)}
-    country="US"
-    gr4vyId="45"
-    environment={
-      select(`Environment`, environmentOptions, 'development', `Public`) as any
-    }
-    debug
-    preferResponse={select(
-      `Prefered server response`,
-      responseOptions,
-      ``,
-      `Development`
-    )}
-  />
-)
+export const Default = () => {
+  const form = useRef<HTMLFormElement>()
+  return (
+    <>
+      <form ref={form} />
+      <Gr4vyEmbed
+        form={form.current}
+        amount={number(`Amount`, 1299, {}, `Public`)}
+        intent={select(`Intent`, intentOptions, 'capture', `Public`) as any}
+        currency={select(`Currency`, currencyOptions, `USD`, `Public`)}
+        apiHost={text(`API host`, `127.0.0.1:3100`, `Public`)}
+        iframeHost={text(`iFrame host`, `127.0.0.1:8080`, `Public`)}
+        token={text(`JWT token`, `1234567`, `Public`)}
+        showButton={boolean(`Enable submit button`, true, `Public`)}
+        country="US"
+        gr4vyId="45"
+        environment={
+          select(
+            `Environment`,
+            environmentOptions,
+            'development',
+            `Public`
+          ) as any
+        }
+        debug
+        preferResponse={select(
+          `Prefered server response`,
+          responseOptions,
+          ``,
+          `Development`
+        )}
+      />
+    </>
+  )
+}

--- a/packages/embed-react/src/index.test.tsx
+++ b/packages/embed-react/src/index.test.tsx
@@ -9,6 +9,7 @@ import React from 'react'
 import Gr4vyEmbed, { Gr4vyEmbedProps } from './Gr4vyEmbed'
 
 const options: Gr4vyEmbedProps & { channel: string } = {
+  form: '#form',
   intent: 'capture',
   iframeHost: `localhost:8080`,
   apiHost: `localhost:3100`,
@@ -30,6 +31,7 @@ test(`should default to be not loaded`, () => {
     intent: 'capture',
     channel: 'mychannel',
     currency: 'GBP',
+    form: '#form',
     element: expect.any(HTMLDivElement),
     iframeHost: 'localhost:8080',
     onEvent: expect.any(Function),

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -76,6 +76,7 @@ The options for this integration are as follows.
 | `store`                   | `ask`       | `'ask'`, `true`, `false` - Explicitly store the payment method or ask the buyer, this is used when a buyerId or buyerExternalIdentifier is provided.                                                                                                 |
 | `theme`                   | `null`      | Theme customisation options (See Theming)                                                                                                                                                                                                            |
 | `token`                   | `null`      | **Required** - The server-side generated JWT token used to authenticate any of the API calls.                                                                                                                                                        |
+| `onComplete`              | `null`      | Callback with a completed transaction object. (Form submission must be handled manually)                                                                                                                                                             |
 
 ### Theming
 
@@ -155,6 +156,20 @@ Returned when the form encounters an API error.
   "message": "No valid API authentication found",
   "details": []
 }
+```
+
+### Custom Form Submission
+
+Embed will automatically submit the payment form with hidden inputs, this can be prevented using the `onComplete` callback.
+
+```ts
+setup({
+  ...,
+  onComplete: (transaction) => {
+    // Handle custom form submission
+  }
+})
+
 ```
 
 ## License

--- a/packages/embed/dev/index.ts
+++ b/packages/embed/dev/index.ts
@@ -31,7 +31,10 @@ root.style.width = '500px'
 form.appendChild(root)
 form.appendChild(input)
 
+const result = document.createElement(`div`)
+
 document.body.appendChild(form)
+document.body.appendChild(result)
 
 setup({
   element: `#root`,
@@ -61,7 +64,15 @@ setup({
       container: 'subtle',
     },
   },
-  environment: 'development',
+  environment: 'production',
   country: 'US',
   display: 'all',
+  // overrides form submission
+  onComplete: (transaction) => {
+    result.innerHTML = `
+      <p>Transaction ID: ${transaction.id}</p>
+      <p>Status: ${transaction.status}</p>
+      <p>Payment Method ID: ${transaction.paymentMethod.id}</p>
+      `
+  },
 })

--- a/packages/embed/src/emitter/emitter.test.ts
+++ b/packages/embed/src/emitter/emitter.test.ts
@@ -172,7 +172,7 @@ describe('createEmitter', () => {
 
     // inject content and submit the form when the transaction was created
     fb.emit('transactionCreated', { id: 'transaction-id' })
-    expect(transactionCreated$.value()).toBe('transaction-id')
+    expect(transactionCreated$.value()).toStrictEqual({ id: 'transaction-id' })
 
     // subscribe to these events and pass them straight to the `onEvent` handler
     fb.emit('formUpdate', {})

--- a/packages/embed/src/emitter/emitter.ts
+++ b/packages/embed/src/emitter/emitter.ts
@@ -57,7 +57,9 @@ export const createEmitter = ({
   on('frameReady', () => emit('updateOptions', options))
   on('resize', (data) => frameHeight$.next(data.frame.height))
   on('optionsLoaded', () => optionsLoaded$.next(true))
-  on('transactionCreated', ({ id }) => transactionCreated$.next(id))
+  on('transactionCreated', (transaction) =>
+    transactionCreated$.next(transaction)
+  )
   on('transactionFailed', (...ars) => transactionFailed$.next(...ars))
 
   formSubmit$.subscribe(() => emit('submitForm'))

--- a/packages/embed/src/form/form.test.ts
+++ b/packages/embed/src/form/form.test.ts
@@ -29,7 +29,7 @@ describe('createFormController', () => {
   describe('onTransactionCreated', () => {
     it('should inject the transaction id', () => {
       createFormController(formNapperMock)
-      transactionCreated$.next('123')
+      transactionCreated$.next({ id: '123', status: 'captured' })
       expect(formNapperMock.inject).toHaveBeenCalledWith(
         'gr4vy_transaction_id',
         '123'
@@ -38,7 +38,7 @@ describe('createFormController', () => {
 
     it('should submit the form', () => {
       createFormController(formNapperMock)
-      transactionCreated$.next('123')
+      transactionCreated$.next({ id: '123', status: 'captured' })
       expect(formNapperMock.submit).toHaveBeenCalled()
     })
   })

--- a/packages/embed/src/form/form.ts
+++ b/packages/embed/src/form/form.ts
@@ -6,13 +6,28 @@ export type FormNapperInstance = {
   submit: () => void
 }
 
-export const createFormController = (form: FormNapperInstance) => {
+export const createFormController = (
+  form: FormNapperInstance,
+  onComplete?: CallableFunction
+) => {
   form.hijack(() => {
     formSubmit$.next()
   })
 
-  transactionCreated$.subscribe((transactionId) => {
-    form.inject(`gr4vy_transaction_id`, transactionId)
-    form.submit()
+  transactionCreated$.subscribe((transaction) => {
+    form.inject(`gr4vy_transaction_id`, transaction.id)
+    form.inject(`gr4vy_transaction_status`, transaction.status)
+
+    // include payment method id if available
+    if (transaction?.paymentMethod?.id) {
+      form.inject(
+        `gr4vy_transaction_payment_method_id`,
+        transaction.paymentMethod.id
+      )
+    }
+
+    return typeof onComplete === 'function'
+      ? onComplete(transaction)
+      : form.submit()
   })
 }

--- a/packages/embed/src/index.test.ts
+++ b/packages/embed/src/index.test.ts
@@ -96,18 +96,4 @@ describe('setup()', () => {
     expect(validate).toHaveBeenCalledWith(invalidConfig)
     expect(createFormController).not.toHaveBeenCalled()
   })
-
-  test('skip form setup if not set in config', () => {
-    ;(validate as jest.Mock).mockReturnValue(true)
-    setup({
-      element: document.querySelector('#app'),
-      amount: 1299,
-      currency: `USD`,
-      iframeHost: `127.0.0.1:8080`,
-      apiHost: `127.0.0.1:3100`,
-      token: `123456`,
-      country: 'US',
-    })
-    expect(createFormController).not.toHaveBeenCalled()
-  })
 })

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -17,7 +17,7 @@ import { validate } from './validation'
  * to append the form to, and a list of valid options for the form.
  */
 export function setup(setupConfig: SetupConfig): void {
-  const { gr4vyId, ...rest } = setupConfig
+  const { gr4vyId, onComplete, ...rest } = setupConfig
   const config: Config = {
     store: 'ask',
     display: 'all',
@@ -49,7 +49,7 @@ export function setup(setupConfig: SetupConfig): void {
   // Form - Optional
   if (config.form) {
     const formNapper = new FormNapper(config.form) as FormNapperInstance
-    createFormController(formNapper)
+    createFormController(formNapper, onComplete)
   }
 
   // Popup + Overlay (Authorizations)

--- a/packages/embed/src/subjects.test.ts
+++ b/packages/embed/src/subjects.test.ts
@@ -39,7 +39,7 @@ test('should complete approval on transaction complete', () => {
   approvalRequired$.next(true)
   let result = false
   const approvalCompleted = approvalCompleted$.subscribe(() => (result = true))
-  transactionCreated$.next('test-transaction-id')
+  transactionCreated$.next({ id: 'test-transaction-id', status: 'captured' })
   approvalCompleted.unsubscribe()
   expect(result).toBe(true)
 })
@@ -48,7 +48,7 @@ test('should skip complete approval if not required on transaction complete', ()
   approvalRequired$.next(false)
   let result = false
   const approvalCompleted = approvalCompleted$.subscribe(() => (result = true))
-  transactionCreated$.next('test-transaction-id')
+  transactionCreated$.next({ id: 'test-transaction-id', status: 'captured' })
   approvalCompleted.unsubscribe()
   expect(result).toBe(false)
 })

--- a/packages/embed/src/subjects.ts
+++ b/packages/embed/src/subjects.ts
@@ -9,7 +9,11 @@ export const approvalCompleted$ = createSubject()
 export const frameHeight$ = createSubject<number>(0)
 export const optionsLoaded$ = createSubject<boolean>(false)
 export const formSubmit$ = createSubject()
-export const transactionCreated$ = createSubject<string>()
+export const transactionCreated$ = createSubject<{
+  id: string
+  status: string
+  paymentMethod?: { id?: string }
+}>()
 export const transactionFailed$ = createSubject()
 
 // Initial events

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -20,6 +20,13 @@ export type Config = {
   theme?: ThemeOptions // Theming options
   locale?: string //  < ISO 639 Language Code > - < ISO 3166 Country Code (optional) >
   display?: 'storedOnly' | 'addOnly' | 'all'
+  onComplete?: (transaction: Transaction) => void
+}
+
+export type Transaction = {
+  id: string
+  status: string
+  paymentMethod?: { id?: string }
 }
 
 export type SetupConfig = Omit<Config, 'iframeHost' | 'apiHost'> & {

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -1,6 +1,6 @@
 export type Config = {
   element: string | HTMLElement | Element // The element to insert the integration at
-  form?: string | HTMLElement | Element // The form to bind the integration to
+  form: string | HTMLElement | Element // The form to bind the integration to
   amount: number // The amount of a given currency to charge
   intent?: 'authorize' | 'capture' | 'approve' // Defines the intent of this API call. This determines the desired initial state of the transaction.
   currency: string // Currency to charge the amount in


### PR DESCRIPTION
Adding an onComplete callback that allows a merchant to handle completion of the Embed transaction.

```ts
setup({
   ...,
   onComplete: (transaction) => {
      // custom logic/form submission goes here
   }
})

```

In React:

```tsx
<Gr4vyEmbed {...} onComplete={() => {...}}/>
```

Here is an example show using `onComplete`

![2021-07-09 14 08 05](https://user-images.githubusercontent.com/1008377/125085647-b8954680-e0c2-11eb-9d39-efab24ceabde.gif)

