### PR TITLE
fix: Resolves SSR issues when using with Next

### DIFF
--- a/packages/embed/__mocks__/styleMock.ts
+++ b/packages/embed/__mocks__/styleMock.ts
@@ -1,0 +1,4 @@
+// CSS should not be referenced outside of a document
+if (typeof document === 'undefined') {
+  throw 'Referencing CSS using webpack style-loader is not supported with SSR'
+}

--- a/packages/embed/node/index.js
+++ b/packages/embed/node/index.js
@@ -1,1 +1,0 @@
-const { setup } = require('../lib')

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,37 +1,36 @@
 {
-    "name": "@gr4vy/embed",
-    "version": "1.3.1",
-    "description": "Embed a credit card form in your web app and store the card details, authorize the card, and capture a transaction.",
-    "main": "lib/index",
-    "types": "lib/index",
-    "author": "Gr4vy <code@gr4vy.com>",
-    "license": "MIT",
-    "repository": "github:gr4vy/embed",
-    "homepage": "https://gr4vy.com",
-    "exports": {
-        "require": "./lib/index.js",
-        "import": "./esm/index.js"
-    },
-    "scripts": {
-        "clean": "rm -rf lib *.tgz",
-        "prebuild": "yarn clean",
-        "dev": "webpack serve --config webpack.dev.js",
-        "build": "tsc && webpack --config webpack.prod.js",
-        "prepack": "yarn build",
-        "lint": "eslint src/ --ext ts",
-        "test": "jest --colors",
-        "test:node": "node node/index.js"
-    },
-    "files": [
-        "esm",
-        "lib",
-        "LICENSE",
-        "README",
-        "CHANGELOG.md"
-    ],
-    "dependencies": {
-        "form-napper": "^2.0.0",
-        "framebus": "^5.0.0"
-    },
-    "gitHead": "6606f868e978fc1aa7368557d2730d52170a9049"
+  "name": "@gr4vy/embed",
+  "version": "1.3.1",
+  "description": "Embed a credit card form in your web app and store the card details, authorize the card, and capture a transaction.",
+  "main": "lib/index",
+  "types": "lib/index",
+  "author": "Gr4vy <code@gr4vy.com>",
+  "license": "MIT",
+  "repository": "github:gr4vy/embed",
+  "homepage": "https://gr4vy.com",
+  "exports": {
+    "require": "./lib/index.js",
+    "import": "./esm/index.js"
+  },
+  "scripts": {
+    "clean": "rm -rf lib *.tgz",
+    "prebuild": "yarn clean",
+    "dev": "webpack serve --config webpack.dev.js",
+    "build": "tsc && webpack --config webpack.prod.js",
+    "prepack": "yarn build",
+    "lint": "eslint src/ --ext ts",
+    "test": "jest --colors"
+  },
+  "files": [
+    "esm",
+    "lib",
+    "LICENSE",
+    "README",
+    "CHANGELOG.md"
+  ],
+  "dependencies": {
+    "form-napper": "^2.0.0",
+    "framebus": "^5.0.0"
+  },
+  "gitHead": "6606f868e978fc1aa7368557d2730d52170a9049"
 }

--- a/packages/embed/src/overlay/overlay.ts
+++ b/packages/embed/src/overlay/overlay.ts
@@ -1,14 +1,20 @@
 import { SubjectManager } from '../subjects'
-import './overlay.css'
 
 const overlayTitle = `Your payment has continued in a new secure window.`
 const overlayPrompt = `Can not see the new window?`
 const overlayLink = `Re-open window`
 
+let isFirstLoad = true
+
 export const createOverlayController = (
   element: HTMLDivElement,
   subject: SubjectManager
 ) => {
+  if (isFirstLoad) {
+    require('./overlay.css')
+    isFirstLoad = false
+  }
+
   element.className = `gr4vy__overlay gr4vy__overlay--hidden`
 
   const Title = document.createElement('div')

--- a/packages/embed/src/skeleton/skeleton.ts
+++ b/packages/embed/src/skeleton/skeleton.ts
@@ -1,12 +1,18 @@
-import './skeleton.css'
 import { SubjectManager } from '../subjects'
 
 const html = String.raw
+
+let isFirstLoad = true
 
 export const createSkeletonController = (
   element: HTMLDivElement,
   subject: SubjectManager
 ) => {
+  if (isFirstLoad) {
+    require('./skeleton.css')
+    isFirstLoad = false
+  }
+
   element.innerHTML = html`<div class="gr4vy__container">
     <div class="gr4vy__loading"></div>
     <div class="gr4vy__skeleton">

--- a/packages/embed/src/ssr.test.ts
+++ b/packages/embed/src/ssr.test.ts
@@ -1,0 +1,8 @@
+/**
+ * @jest-environment node
+ */
+
+test('should render in SSR', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('./index')
+})


### PR DESCRIPTION
SSR has issues with webpack `style-loader` as the `document` is not present in a node environment.
This is due to the styles being injected to the document.

I have added a test that runs in the `node` environment specifically to check this (I removed the previous one as it was done on the build, not whilst running `yarn test`). `styleMock` will throw an exception if document is undefined - we should not be loading and styles unless we have a DOM :-)

![Screenshot 2021-07-14 at 13 33 56](https://user-images.githubusercontent.com/1008377/125623361-3b4dc17a-3d81-469d-87fb-0cb1d75dac4d.png)

There might be a better of solving this in terms of how we load styles onto the merchants page. 

