### PR TITLE
Add cloud build configs

### DIFF
--- a/cloudbuild/cloudbuild-cdn.yaml
+++ b/cloudbuild/cloudbuild-cdn.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'restore cache'
-    name: gcr.io/gr4vy-admin/restore_cache
+    name: gcr.io/${PROJECT_ID}/restore_cache
     args:
       [
         '--bucket=gs://${_CACHE_BUCKET}',
@@ -70,7 +70,7 @@ steps:
 
   - id: 'save cache'
     waitFor: ['yarn build']
-    name: gcr.io/gr4vy-admin/save_cache
+    name: gcr.io/${PROJECT_ID}/save_cache
     args:
       [
         '--bucket=gs://${_CACHE_BUCKET}/',
@@ -82,7 +82,7 @@ steps:
 substitutions:
   _NODE_VERSION: '14'
   _ARTIFACT_STORAGE_BUCKET: ''
-  _CACHE_BUCKET: 'embed-cdn-build-cache-storage'
+  _CACHE_BUCKET: ''
 
 options:
   dynamic_substitutions: true

--- a/cloudbuild/cloudbuild-cdn.yaml
+++ b/cloudbuild/cloudbuild-cdn.yaml
@@ -1,0 +1,91 @@
+steps:
+  - id: 'restore cache'
+    name: gcr.io/gr4vy-admin/restore_cache
+    args:
+      [
+        '--bucket=gs://${_CACHE_BUCKET}',
+        '--key=node_modules-$( checksum yarn.lock )',
+        '--key_fallback=node_modules-',
+      ]
+
+  - id: 'yarn install'
+    name: node:${_NODE_VERSION}-alpine
+    entrypoint: yarn
+    args: ['install']
+
+  - id: 'scan with trivy'
+    name: 'aquasec/trivy:latest'
+    args: ['fs', '.']
+    env:
+      - 'TRIVY_EXIT_CODE=0'
+      - 'TRIVY_NO_PROGRESS=true'
+      - 'TRIVY_IGNORE_UNFIXED=true'
+
+  - id: 'yarn bootstrap'
+    name: node:${_NODE_VERSION}-alpine
+    entrypoint: yarn
+    args: ['bootstrap']
+
+  - id: 'yarn build'
+    name: node:${_NODE_VERSION}-alpine
+    entrypoint: yarn
+    args: ['build']
+
+  - id: 'push to storage bucket'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:340.0.0-alpine'
+    entrypoint: gsutil
+    args:
+      [
+        '-m',
+        'cp',
+        '-r',
+        '-Z',
+        './packages/embed-cdn/lib/gr4vy-embed.js',
+        'gs://$_ARTIFACT_STORAGE_BUCKET/$COMMIT_SHA/embed.latest.js',
+      ]
+
+  - id: 'remove cache-control metadata'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:340.0.0-alpine'
+    entrypoint: gsutil
+    args:
+      [
+        '-m',
+        'setmeta',
+        '-h',
+        'Cache-Control',
+        'gs://$_ARTIFACT_STORAGE_BUCKET/$COMMIT_SHA/**',
+      ]
+
+  - id: 'Set cache-control on assets'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:340.0.0-alpine'
+    entrypoint: gsutil
+    args:
+      [
+        '-m',
+        'setmeta',
+        '-h',
+        'Cache-Control: public, max-age=31536000',
+        'gs://$_ARTIFACT_STORAGE_BUCKET/$COMMIT_SHA/**/*.js',
+      ]
+
+  - id: 'save cache'
+    waitFor: ['yarn build']
+    name: gcr.io/gr4vy-admin/save_cache
+    args:
+      [
+        '--bucket=gs://${_CACHE_BUCKET}/',
+        '--key=node_modules-$( checksum yarn.lock )',
+        '--path=node_modules',
+        '--no-clobber',
+      ]
+
+substitutions:
+  _NODE_VERSION: '14'
+  _ARTIFACT_STORAGE_BUCKET: ''
+  _CACHE_BUCKET: 'embed-cdn-build-cache-storage'
+
+options:
+  dynamic_substitutions: true
+  substitution_option: 'ALLOW_LOOSE'
+
+timeout: 900s

--- a/cloudbuild/deploy.yaml
+++ b/cloudbuild/deploy.yaml
@@ -1,0 +1,30 @@
+steps:
+  - id: 'Deploy pre-built version'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
+    entrypoint: gsutil
+    args:
+      [
+        '-m',
+        'rsync',
+        '-d',
+        '-r',
+        'gs://gr4vy-embed-cdn-version-repository/${COMMIT_SHA}',
+        'gs://$_ARTIFACT_STORAGE_BUCKET/',
+      ]
+
+  - id: 'Invalidate CDN cache'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
+    entrypoint: ash
+    args:
+      - '-c'
+      - >-
+        gcloud compute url-maps invalidate-cdn-cache $_URL_MAP --path='/*' --async --project $PROJECT_ID
+
+substitutions:
+  _GR4VY_ID: ${PROJECT_ID%-*}
+  _ARTIFACT_STORAGE_BUCKET: embed-cdn-${_GR4VY_ID}-gr4vy-app
+  _URL_MAP: embed-cdn-${_GR4VY_ID}-gr4vy-app-url-map
+
+options:
+  dynamic_substitutions: true
+  substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION
Adding two Cloud Build config files.

- `cloudbuild-cdn.yaml` to build and move the embed-cdn `gr4vy-embed.js` file to a storage bucket.
- `deploy.yaml` to be used by our deployment process copy the required file from storage and into the Gr4vy instance being deployed to.