### PR TITLE
Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.repository_owner == 'gr4vy' && github.ref == 'refs/heads/main'"
     runs-on: ubuntu-latest
 
     needs:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "auto": {
     "onlyPublishWithReleaseLabel": true,
     "plugins": [
+      "npm",
       "released"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "storybook": "lerna run storybook --parallel"
   },
   "auto": {
-    "onlyPublishWithReleaseLabel": true
+    "onlyPublishWithReleaseLabel": true,
+    "plugins": [
+      "released"
+    ]
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
This does a couple of things:
- Turns off canary releases (I want to revisit this, maybe setup a pre-release branch)
- Only runs on the main branch of gr4vy
- Adds the 'release' plugin to post back to issues/PR's when something has been released.