### PR TITLE
feat: add event paymentMethodSelected

### DIFF
--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -130,7 +130,12 @@ export function setup(setupConfig: SetupConfig): void {
     (message) => {
       log(`Page received`, message, config.debug)
       if (
-        ['formUpdate', 'transactionCreated', 'apiError'].includes(message.type)
+        [
+          'formUpdate',
+          'transactionCreated',
+          'apiError',
+          'paymentMethodSelected',
+        ].includes(message.type)
       ) {
         config.onEvent?.(message.type, message.data)
       }


### PR DESCRIPTION
Adds the payment method selected event to Embed - However this does not work as documented in https://gr4vy.com/docs/next/embed/events#paymentmethodselected <- Can we change the documentation? @cbetta 

I think there are two category of events `UI Events` (Clicked/Selected)  and `Resource events` (Saved/Changed/Updated something)