### PR TITLE
Fix skeleton styles to respect theme values

### DIFF
--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -76,7 +76,7 @@ export function setup(setupConfig: SetupConfig): void {
 
   // Loader
   const loader = document.createElement('div')
-  createSkeletonController(loader, subjectManager)
+  createSkeletonController(loader, subjectManager, config.theme)
 
   // Overlay
   const overlay = document.createElement('div')

--- a/packages/embed/src/skeleton/skeleton.css
+++ b/packages/embed/src/skeleton/skeleton.css
@@ -7,46 +7,47 @@
   }
 }
 
-.gr4vy__loading {
-  height: 8px;
-  background-image: linear-gradient(
-    90deg,
-    #009cde 25%,
-    #bee7fa 25%,
-    #bee7fa 75%,
-    #009cde 75%
-  );
-  background-size: 600px 8px;
-  -webkit-animation: gr4vy-sweep 2s infinite cubic-bezier(0.2, 0.75, 0.77, 0.25);
-  animation: gr4vy-sweep 2s infinite cubic-bezier(0.2, 0.75, 0.77, 0.25);
-}
-
 .gr4vy__skeleton {
   display: flex;
-  border-bottom: 1px solid #bdc6d9;
+  border-bottom: var(--gr4vy-borderWidths-container, 1px) solid
+    var(--gr4vy-colors-containerBorder, #f2f2f2);
   padding: 16px;
 }
+
 .gr4vy__skeleton:last-child {
   border-bottom: none;
 }
+
 .gr4vy__skeleton__radio {
   border-radius: 50%;
   height: 16px;
   width: 16px;
   margin-bottom: 4px;
   margin-top: 4px;
-  background-color: #dadbdc;
+  background-color: var(--gr4vy-colors-containerBorder, #f2f2f2);
 }
+
 .gr4vy__skeleton__block {
   width: 50%;
   height: 16px;
-  background-color: #dadbdc;
+  background-image: linear-gradient(
+    90deg,
+    var(--gr4vy-colors-containerBorder, #f2f2f2) 30%,
+    var(--gr4vy-colors-containerBackground, #ffffff) 50%,
+    var(--gr4vy-colors-containerBorder, #f2f2f2) 70%
+  );
+  background-size: 600px;
   margin-bottom: 4px;
   margin-top: 4px;
   margin-left: 16px;
-  border-radius: 2px;
+  border-radius: var(--gr4vy-radii-input, 0);
+  -webkit-animation: gr4vy-sweep 1s infinite cubic-bezier(0.2, 0.75, 0.77, 0.25);
+  animation: gr4vy-sweep 1s infinite cubic-bezier(0.2, 0.75, 0.77, 0.25);
 }
 .gr4vy__container {
-  border: 1px solid #bdc6d9;
+  border: var(--gr4vy-borderWidths-container, 1px) solid
+    var(--gr4vy-colors-containerBorder, #f2f2f2);
+  border-radius: var(--gr4vy-radii-container, 0);
+  background: var(--gr4vy-colors-pageBackground, #ffffff);
   max-width: 480px;
 }

--- a/packages/embed/src/skeleton/skeleton.test.ts
+++ b/packages/embed/src/skeleton/skeleton.test.ts
@@ -7,7 +7,7 @@ describe('createSkeletonController', () => {
       remove: jest.fn(),
     } as any
     const subject = createSubjectManager()
-    createSkeletonController(mockElement, subject)
+    createSkeletonController(mockElement, subject, undefined)
     subject.optionsLoaded$.next(true)
     expect(mockElement.remove).toHaveBeenCalled()
   })

--- a/packages/embed/src/skeleton/skeleton.ts
+++ b/packages/embed/src/skeleton/skeleton.ts
@@ -1,4 +1,5 @@
 import { SubjectManager } from '../subjects'
+import { createTheme, injectThemeVariables } from '../theme'
 
 const html = String.raw
 
@@ -6,15 +7,19 @@ let isFirstLoad = true
 
 export const createSkeletonController = (
   element: HTMLDivElement,
-  subject: SubjectManager
+  subject: SubjectManager,
+  theme: any
 ) => {
   if (isFirstLoad) {
     require('./skeleton.css')
     isFirstLoad = false
   }
 
+  if (theme) {
+    injectThemeVariables(createTheme(theme), element)
+  }
+
   element.innerHTML = html`<div class="gr4vy__container">
-    <div class="gr4vy__loading"></div>
     <div class="gr4vy__skeleton">
       <div class="gr4vy__skeleton__radio"></div>
       <div class="gr4vy__skeleton__block"></div>

--- a/packages/embed/src/theme/create-theme.spec.ts
+++ b/packages/embed/src/theme/create-theme.spec.ts
@@ -1,0 +1,45 @@
+import { createTheme } from './create-theme'
+
+describe('createTheme', () => {
+  test('creates an empty theme', () => {
+    const result = createTheme()
+    expect(result).toEqual({})
+  })
+
+  test('includes custom colors', () => {
+    const result = createTheme({
+      colors: {
+        primary: 'foo',
+      },
+    })
+    expect(result.colors.primary).toEqual('foo')
+  })
+
+  test('resolves radii values', () => {
+    const result = createTheme({
+      radii: {
+        container: 'rounded',
+        input: 'subtle',
+      },
+    })
+    expect(result.radii).toEqual({
+      container: '4px',
+      input: '2px',
+    })
+  })
+
+  test('set custom border widths', () => {
+    const result = createTheme({
+      borderWidths: {
+        input: 'thin',
+        container: 'thick',
+        focus: 'thin',
+      },
+    })
+    expect(result.borderWidths).toEqual({
+      container: '2px',
+      input: '1px',
+      focus: '1px',
+    })
+  })
+})

--- a/packages/embed/src/theme/create-theme.ts
+++ b/packages/embed/src/theme/create-theme.ts
@@ -1,0 +1,55 @@
+type DeepPartial<T> = {
+  // eslint-disable-next-line
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
+}
+
+export type ThemeOptions = {
+  borderWidths: Record<string, string>
+  colors: Record<string, string>
+  radii: Record<string, string>
+}
+
+const borderWidthMap: Record<'none' | 'thin' | 'thick', string> = {
+  none: '0',
+  thin: '1px',
+  thick: '2px',
+}
+
+const radiiMap: Record<'none' | 'subtle' | 'rounded', string> = {
+  rounded: '4px',
+  subtle: '2px',
+  none: '0',
+}
+
+/**
+ * Resolves a value object given a map
+ */
+const resolveMapValues = (map, values: Record<string, string> = {}) =>
+  Object.keys(values).reduce((acc, key) => {
+    return { ...acc, [key]: map[values[key]] }
+  }, {})
+
+/**
+ * Resolves theme values based on mapped types
+ */
+export const createTheme = (options?: DeepPartial<ThemeOptions>): any => {
+  const theme = {}
+
+  if (options?.colors) {
+    theme['colors'] = { ...options.colors }
+  }
+
+  if (options?.borderWidths) {
+    theme['borderWidths'] = resolveMapValues(borderWidthMap, {
+      ...options.borderWidths,
+    })
+  }
+
+  if (options?.radii) {
+    theme['radii'] = resolveMapValues(radiiMap, {
+      ...options.radii,
+    })
+  }
+
+  return theme
+}

--- a/packages/embed/src/theme/index.ts
+++ b/packages/embed/src/theme/index.ts
@@ -1,0 +1,2 @@
+export * from './utils'
+export * from './create-theme'

--- a/packages/embed/src/theme/utils.spec.ts
+++ b/packages/embed/src/theme/utils.spec.ts
@@ -1,0 +1,11 @@
+import { themeToVars } from './utils'
+
+test('themeToVars flattens a theme to an array of css variable tuples', () => {
+  const result = themeToVars({
+    foo: {
+      bar: 'test',
+    },
+  })
+
+  expect(result).toEqual([['--gr4vy-foo-bar', 'test']])
+})

--- a/packages/embed/src/theme/utils.ts
+++ b/packages/embed/src/theme/utils.ts
@@ -1,0 +1,21 @@
+export const themeToVars = (theme: Record<string, Record<string, any>>) => {
+  const vars = []
+  Object.keys(theme).forEach((parentKey) => {
+    Object.keys(theme[parentKey]).forEach((childKey) => {
+      vars.push([
+        `--gr4vy-${parentKey}-${childKey}`,
+        `${theme[parentKey][childKey]}`,
+      ])
+    })
+  })
+  return vars
+}
+
+export const injectThemeVariables = (theme, element) => {
+  // cleanup existing variables
+  element.removeAttribute('style')
+
+  themeToVars(theme).forEach(([key, value]) =>
+    element.style.setProperty(key, value)
+  )
+}


### PR DESCRIPTION
This will need to be refactored (we can look at extracting theming utils out to its own package). 
This doesn't need to be solved right now - this is lift of existing theming functionality, but slightly modified to include a `gr4vy-` prefix on css variables (These will live on the merchants page).

**Before**
![Screenshot 2021-10-28 at 09 41 16](https://user-images.githubusercontent.com/1008377/139225134-9017adc6-2d3d-4cc4-a05f-31b30f978760.png)

**After**
![Screenshot 2021-10-28 at 09 58 08](https://user-images.githubusercontent.com/1008377/139225129-10b84c7e-aebe-4666-8b0c-f1c2a4914544.png)