### PR TITLE
feat: add apple pay support

### DIFF
--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -31,5 +31,8 @@
   "dependencies": {
     "form-napper": "^2.0.0"
   },
+  "devDependencies": {
+    "@types/applepayjs": "^3.0.2"
+  },
   "gitHead": "6606f868e978fc1aa7368557d2730d52170a9049"
 }

--- a/packages/embed/src/apple-pay/apple-pay.test.ts
+++ b/packages/embed/src/apple-pay/apple-pay.test.ts
@@ -21,9 +21,9 @@ beforeEach(() => {
 })
 
 test('should start a session with version 3 and session data', () => {
-  createApplePayController(mockSubjectManager)
+  createApplePayController(mockSubjectManager, 3)
 
-  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+  mockSubjectManager.appleStartSession$.next({ foo: 'bar' } as any)
 
   expect(
     (window.ApplePaySession as unknown) as jest.Mock
@@ -35,7 +35,7 @@ test('should emit an error if session fails to create', (done) => {
   window.ApplePaySession = (() => {
     throw new Error('Test error')
   }) as any
-  createApplePayController(mockSubjectManager)
+  createApplePayController(mockSubjectManager, 3)
 
   // assert
   const subscription = mockSubjectManager.appleSessionError$.subscribe(() => {
@@ -44,12 +44,12 @@ test('should emit an error if session fails to create', (done) => {
   })
 
   // act
-  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+  mockSubjectManager.appleStartSession$.next({ foo: 'bar' } as any)
 })
 
 test('should register an onvalidatemerchant callback', (done) => {
-  createApplePayController(mockSubjectManager)
-  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+  createApplePayController(mockSubjectManager, 3)
+  mockSubjectManager.appleStartSession$.next({ foo: 'bar' } as any)
 
   // assert
   const subscription = mockSubjectManager.appleValidateMerchant$.subscribe(
@@ -65,8 +65,8 @@ test('should register an onvalidatemerchant callback', (done) => {
 })
 
 test('should register an onpaymentauthorized callback', (done) => {
-  createApplePayController(mockSubjectManager)
-  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+  createApplePayController(mockSubjectManager, 3)
+  mockSubjectManager.appleStartSession$.next({ foo: 'bar' } as any)
 
   // assert
   const subscription = mockSubjectManager.applePayAuthorized$.subscribe(
@@ -82,10 +82,10 @@ test('should register an onpaymentauthorized callback', (done) => {
 })
 
 test('should complete merchant validation', () => {
-  createApplePayController(mockSubjectManager)
-  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+  createApplePayController(mockSubjectManager, 3)
+  mockSubjectManager.appleStartSession$.next({ foo: 'bar' } as any)
 
-  mockSubjectManager.completeMerchantValidation$.next('test-data')
+  mockSubjectManager.appleCompleteMerchantValidation$.next('test-data')
 
   expect(mockAppleSession.completeMerchantValidation).toHaveBeenCalledWith(
     'test-data'
@@ -93,8 +93,8 @@ test('should complete merchant validation', () => {
 })
 
 test('should complete a successful payment', () => {
-  createApplePayController(mockSubjectManager)
-  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+  createApplePayController(mockSubjectManager, 3)
+  mockSubjectManager.appleStartSession$.next({ foo: 'bar' } as any)
 
   mockSubjectManager.appleCompletePayment$.next(true)
 
@@ -102,8 +102,8 @@ test('should complete a successful payment', () => {
 })
 
 test('should complete a failed payment', () => {
-  createApplePayController(mockSubjectManager)
-  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+  createApplePayController(mockSubjectManager, 3)
+  mockSubjectManager.appleStartSession$.next({ foo: 'bar' } as any)
 
   mockSubjectManager.appleCompletePayment$.next(false)
 
@@ -111,8 +111,8 @@ test('should complete a failed payment', () => {
 })
 
 test('should abort an applepay session', () => {
-  createApplePayController(mockSubjectManager)
-  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+  createApplePayController(mockSubjectManager, 3)
+  mockSubjectManager.appleStartSession$.next({ foo: 'bar' } as any)
 
   mockSubjectManager.appleAbortSession$.next()
 

--- a/packages/embed/src/apple-pay/apple-pay.test.ts
+++ b/packages/embed/src/apple-pay/apple-pay.test.ts
@@ -1,0 +1,120 @@
+import { createSubjectManager } from '../subjects'
+import { createApplePayController } from './apple-pay'
+
+let mockAppleSession, mockSubjectManager
+
+beforeEach(() => {
+  mockAppleSession = {
+    onvalidatemerchant: jest.fn(),
+    onpaymentauthorized: jest.fn(),
+    begin: jest.fn(),
+    completeMerchantValidation: jest.fn(),
+    completePayment: jest.fn(),
+    abort: jest.fn(),
+  }
+  window.ApplePaySession = (jest
+    .fn()
+    .mockReturnValue(mockAppleSession) as unknown) as ApplePaySession
+  ;(window.ApplePaySession as any).STATUS_SUCCESS = 1
+  ;(window.ApplePaySession as any).STATUS_FAILURE = 0
+  mockSubjectManager = createSubjectManager()
+})
+
+test('should start a session with version 3 and session data', () => {
+  createApplePayController(mockSubjectManager)
+
+  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+
+  expect(
+    (window.ApplePaySession as unknown) as jest.Mock
+  ).toHaveBeenCalledWith(3, { foo: 'bar' })
+  expect(mockAppleSession.begin).toHaveBeenCalled()
+})
+
+test('should emit an error if session fails to create', (done) => {
+  window.ApplePaySession = (() => {
+    throw new Error('Test error')
+  }) as any
+  createApplePayController(mockSubjectManager)
+
+  // assert
+  const subscription = mockSubjectManager.appleSessionError$.subscribe(() => {
+    subscription.unsubscribe()
+    done()
+  })
+
+  // act
+  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+})
+
+test('should register an onvalidatemerchant callback', (done) => {
+  createApplePayController(mockSubjectManager)
+  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+
+  // assert
+  const subscription = mockSubjectManager.appleValidateMerchant$.subscribe(
+    (validationUrl) => {
+      subscription.unsubscribe()
+      expect(validationUrl).toBe('test-url')
+      done()
+    }
+  )
+
+  // act
+  mockAppleSession.onvalidatemerchant({ validationURL: 'test-url' })
+})
+
+test('should register an onpaymentauthorized callback', (done) => {
+  createApplePayController(mockSubjectManager)
+  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+
+  // assert
+  const subscription = mockSubjectManager.applePayAuthorized$.subscribe(
+    (token) => {
+      subscription.unsubscribe()
+      expect(token).toBe('token-123')
+      done()
+    }
+  )
+
+  // act
+  mockAppleSession.onpaymentauthorized({ payment: { token: 'token-123' } })
+})
+
+test('should complete merchant validation', () => {
+  createApplePayController(mockSubjectManager)
+  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+
+  mockSubjectManager.completeMerchantValidation$.next('test-data')
+
+  expect(mockAppleSession.completeMerchantValidation).toHaveBeenCalledWith(
+    'test-data'
+  )
+})
+
+test('should complete a successful payment', () => {
+  createApplePayController(mockSubjectManager)
+  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+
+  mockSubjectManager.appleCompletePayment$.next(true)
+
+  expect(mockAppleSession.completePayment).toHaveBeenCalledWith(1)
+})
+
+test('should complete a failed payment', () => {
+  createApplePayController(mockSubjectManager)
+  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+
+  mockSubjectManager.appleCompletePayment$.next(false)
+
+  expect(mockAppleSession.completePayment).toHaveBeenCalledWith(0)
+})
+
+test('should abort an applepay session', () => {
+  createApplePayController(mockSubjectManager)
+  mockSubjectManager.startAppleSession$.next({ foo: 'bar' } as any)
+
+  mockSubjectManager.appleAbortSession$.next()
+
+  expect(mockAppleSession.abort).toHaveBeenCalledWith()
+})

--- a/packages/embed/src/apple-pay/apple-pay.ts
+++ b/packages/embed/src/apple-pay/apple-pay.ts
@@ -1,0 +1,61 @@
+import { SubjectManager } from '../subjects'
+
+declare global {
+  interface Window {
+    ApplePaySession?: ApplePaySession
+  }
+}
+
+export const createApplePayController = (
+  subjectManager: Pick<
+    SubjectManager,
+    | 'appleAbortSession$'
+    | 'startAppleSession$'
+    | 'appleValidateMerchant$'
+    | 'applePayAuthorized$'
+    | 'completeMerchantValidation$'
+    | 'appleCompletePayment$'
+    | 'appleSessionError$'
+  >
+) => {
+  let session: ApplePaySession // only a single session at a time
+
+  subjectManager.startAppleSession$.subscribe((data) => {
+    try {
+      session = new ApplePaySession(3, data)
+
+      // handle merchant validation
+      session.onvalidatemerchant = (event) => {
+        subjectManager.appleValidateMerchant$.next(event.validationURL)
+      }
+
+      // handle payment authorization
+      session.onpaymentauthorized = (event) => {
+        subjectManager.applePayAuthorized$.next(event.payment.token)
+      }
+
+      // start the session
+      session.begin()
+    } catch {
+      subjectManager.appleSessionError$.next()
+    }
+  })
+
+  // handle payment completion
+  subjectManager.completeMerchantValidation$.subscribe((data) => {
+    session.completeMerchantValidation(data)
+  })
+
+  subjectManager.appleAbortSession$.subscribe(() => {
+    session?.abort && session.abort()
+  })
+
+  // handle
+  subjectManager.appleCompletePayment$.subscribe((result) => {
+    if (result) {
+      session.completePayment(ApplePaySession.STATUS_SUCCESS)
+    } else {
+      session.completePayment(ApplePaySession.STATUS_FAILURE)
+    }
+  })
+}

--- a/packages/embed/src/apple-pay/apple-pay.ts
+++ b/packages/embed/src/apple-pay/apple-pay.ts
@@ -10,19 +10,20 @@ export const createApplePayController = (
   subjectManager: Pick<
     SubjectManager,
     | 'appleAbortSession$'
-    | 'startAppleSession$'
+    | 'appleStartSession$'
     | 'appleValidateMerchant$'
     | 'applePayAuthorized$'
-    | 'completeMerchantValidation$'
+    | 'appleCompleteMerchantValidation$'
     | 'appleCompletePayment$'
     | 'appleSessionError$'
-  >
+  >,
+  version: 3 | 4 | 5
 ) => {
   let session: ApplePaySession // only a single session at a time
 
-  subjectManager.startAppleSession$.subscribe((data) => {
+  subjectManager.appleStartSession$.subscribe((data) => {
     try {
-      session = new ApplePaySession(3, data)
+      session = new ApplePaySession(version, data)
 
       // handle merchant validation
       session.onvalidatemerchant = (event) => {
@@ -42,7 +43,7 @@ export const createApplePayController = (
   })
 
   // handle payment completion
-  subjectManager.completeMerchantValidation$.subscribe((data) => {
+  subjectManager.appleCompleteMerchantValidation$.subscribe((data) => {
     session.completeMerchantValidation(data)
   })
 

--- a/packages/embed/src/apple-pay/browser-support.test.ts
+++ b/packages/embed/src/apple-pay/browser-support.test.ts
@@ -1,0 +1,47 @@
+import {
+  browserSupportsApplePay,
+  detectSupportedVersion,
+} from './browser-support'
+
+beforeEach(() => {
+  window.ApplePaySession = ({
+    canMakePayments: jest.fn(),
+    supportsVersion: jest.fn(),
+  } as unknown) as ApplePaySession
+})
+
+test('checks support for apple pay version 3', () => {
+  const dataset: Array<[boolean, number, boolean]> = [
+    [false, 3, false],
+    [true, 3, true],
+    [true, 2, false],
+    [true, 4, true],
+  ]
+
+  dataset.forEach(([canMakePayments, version, expected]) => {
+    ApplePaySession.canMakePayments = () => canMakePayments
+    ApplePaySession.supportsVersion = (checkVersion) => version >= checkVersion
+
+    const result = browserSupportsApplePay()
+
+    expect(result).toBe(expected)
+  })
+})
+
+test('checks for later support of apple pay', () => {
+  const dataset: Array<[number, number]> = [
+    [1, null],
+    [3, 3],
+    [4, 4],
+    [8, 5],
+  ]
+
+  dataset.forEach(([supportedVersion, expected]) => {
+    ApplePaySession.supportsVersion = (checkVersion) =>
+      checkVersion <= supportedVersion
+
+    const result = detectSupportedVersion()
+
+    expect(result).toBe(expected)
+  })
+})

--- a/packages/embed/src/apple-pay/browser-support.ts
+++ b/packages/embed/src/apple-pay/browser-support.ts
@@ -1,0 +1,31 @@
+declare global {
+  interface Window {
+    ApplePaySession?: ApplePaySession
+  }
+}
+
+export const browserSupportsApplePay = () => {
+  let isSupported = false
+  try {
+    isSupported =
+      window.ApplePaySession &&
+      ApplePaySession.canMakePayments() &&
+      ApplePaySession.supportsVersion(3)
+  } catch {
+    // Apple Pay not supported and/or not a secure context
+  }
+  return isSupported
+}
+
+export const detectSupportedVersion = () => {
+  if (ApplePaySession.supportsVersion(5)) {
+    return 5
+  }
+  if (ApplePaySession.supportsVersion(4)) {
+    return 4
+  }
+  if (ApplePaySession.supportsVersion(3)) {
+    return 3
+  }
+  return null
+}

--- a/packages/embed/src/apple-pay/index.ts
+++ b/packages/embed/src/apple-pay/index.ts
@@ -1,0 +1,2 @@
+export * from './apple-pay'
+export * from './browser-support'

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -109,7 +109,7 @@ export function setup(setupConfig: SetupConfig): void {
     : 0
 
   if (supportedApplePayVersion) {
-    createApplePayController(subjectManager)
+    createApplePayController(subjectManager, supportedApplePayVersion)
   }
 
   // Attach elements to the DOM
@@ -124,8 +124,9 @@ export function setup(setupConfig: SetupConfig): void {
     optionsLoaded: subjectManager.optionsLoaded$.next,
     transactionCreated: subjectManager.transactionCreated$.next,
     transactionFailed: subjectManager.transactionFailed$.next,
-    startAppleSession: subjectManager.startAppleSession$.next,
-    completeMerchantValidation: subjectManager.completeMerchantValidation$.next,
+    appleStartSession: subjectManager.appleStartSession$.next,
+    appleCompleteMerchantValidation:
+      subjectManager.appleCompleteMerchantValidation$.next,
     appleCompletePayment: subjectManager.appleCompletePayment$.next,
     appleAbortSession: subjectManager.appleAbortSession$.next,
     frameReady: () =>

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -1,3 +1,8 @@
+import {
+  createApplePayController,
+  browserSupportsApplePay,
+  detectSupportedVersion,
+} from './apple-pay'
 import { createConfig } from './create-config'
 import { createFormController } from './form'
 import { createFrameController } from './frame'
@@ -98,6 +103,15 @@ export function setup(setupConfig: SetupConfig): void {
   const frame = document.createElement('iframe')
   createFrameController(frame, config.iframeSrc, subjectManager)
 
+  // Apple Pay
+  const supportedApplePayVersion = browserSupportsApplePay()
+    ? detectSupportedVersion()
+    : 0
+
+  if (supportedApplePayVersion) {
+    createApplePayController(subjectManager)
+  }
+
   // Attach elements to the DOM
   config.element.append(overlay, loader, frame)
 
@@ -110,10 +124,17 @@ export function setup(setupConfig: SetupConfig): void {
     optionsLoaded: subjectManager.optionsLoaded$.next,
     transactionCreated: subjectManager.transactionCreated$.next,
     transactionFailed: subjectManager.transactionFailed$.next,
+    startAppleSession: subjectManager.startAppleSession$.next,
+    completeMerchantValidation: subjectManager.completeMerchantValidation$.next,
+    appleCompletePayment: subjectManager.appleCompletePayment$.next,
+    appleAbortSession: subjectManager.appleAbortSession$.next,
     frameReady: () =>
       dispatch({
         type: 'updateOptions',
-        data: pick<Config>(config, optionKeys),
+        data: {
+          ...pick<Config>(config, optionKeys),
+          supportedApplePayVersion,
+        },
       }),
   }
 
@@ -164,6 +185,12 @@ export function setup(setupConfig: SetupConfig): void {
   subjectManager.formSubmit$.subscribe(() => dispatch({ type: 'submitForm' }))
   subjectManager.approvalCancelled$.subscribe(() =>
     dispatch({ type: 'approvalCancelled' })
+  )
+  subjectManager.applePayAuthorized$.subscribe((token) =>
+    dispatch({ type: 'applePayAuthorized', data: token })
+  )
+  subjectManager.appleValidateMerchant$.subscribe((validationUrl) =>
+    dispatch({ type: 'appleValidateMerchant', data: validationUrl })
   )
 
   window.addEventListener('message', messageHandler)

--- a/packages/embed/src/subjects.ts
+++ b/packages/embed/src/subjects.ts
@@ -28,9 +28,9 @@ export const createSubjectManager = () => {
       paymentMethod?: { id?: string }
     }>(),
     transactionFailed$: createSubject(),
-    startAppleSession$: createSubject<ApplePayJS.ApplePayPaymentRequest>(),
+    appleStartSession$: createSubject<ApplePayJS.ApplePayPaymentRequest>(),
     appleValidateMerchant$: createSubject<string>(),
-    completeMerchantValidation$: createSubject<any>(),
+    appleCompleteMerchantValidation$: createSubject<any>(),
     applePayAuthorized$: createSubject<ApplePayJS.ApplePayPaymentToken>(),
     appleCompletePayment$: createSubject<boolean>(),
     appleAbortSession$: createSubject(),

--- a/packages/embed/src/subjects.ts
+++ b/packages/embed/src/subjects.ts
@@ -28,6 +28,13 @@ export const createSubjectManager = () => {
       paymentMethod?: { id?: string }
     }>(),
     transactionFailed$: createSubject(),
+    startAppleSession$: createSubject<ApplePayJS.ApplePayPaymentRequest>(),
+    appleValidateMerchant$: createSubject<string>(),
+    completeMerchantValidation$: createSubject<any>(),
+    applePayAuthorized$: createSubject<ApplePayJS.ApplePayPaymentToken>(),
+    appleCompletePayment$: createSubject<boolean>(),
+    appleAbortSession$: createSubject(),
+    appleSessionError$: createSubject(),
   }
 
   subjects.formSubmit$.subscribe(() => {

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -181,4 +181,19 @@ export type Message = { channel: string; data?: unknown } & (
   | {
       type: 'submitForm'
     }
+  | {
+      type: 'appleAbortSession'
+    }
+  | {
+      type: 'appleCompletePayment'
+      data: boolean
+    }
+  | {
+      type: 'completeMerchantValidation'
+      data: any
+    }
+  | {
+      type: 'startAppleSession'
+      data: ApplePayJS.ApplePayPaymentRequest
+    }
 )

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -189,11 +189,11 @@ export type Message = { channel: string; data?: unknown } & (
       data: boolean
     }
   | {
-      type: 'completeMerchantValidation'
+      type: 'appleCompleteMerchantValidation'
       data: any
     }
   | {
-      type: 'startAppleSession'
+      type: 'appleStartSession'
       data: ApplePayJS.ApplePayPaymentRequest
     }
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -3219,6 +3219,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/applepayjs@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/applepayjs/-/applepayjs-3.0.2.tgz#9de0543627f445d7a767003ec7f9264e17e9bc5b"
+  integrity sha512-rxw8jS/eDZ3ceBGThboHrB+TFbwrqGhOMRXSQjNBfxtQorK/mc9Xmu2JSKT5yqrJkQaZT/podzhm8OOdVI+Dow==
+
 "@types/asn1js@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/asn1js/-/asn1js-2.0.0.tgz#10ca75692575744d0117098148a8dc84cbee6682"


### PR DESCRIPTION
Add support for Apple Pay - also detects the version of the API being used and attempts to upgrade to version 5 (broadest set of card schemes), but at a minimum fallbacks to 3 (pre 3 has a subtly different api).