### PR TITLE
Resolves issues cancelling Apple Pay

### DIFF
--- a/packages/embed/src/apple-pay/apple-pay.ts
+++ b/packages/embed/src/apple-pay/apple-pay.ts
@@ -16,6 +16,8 @@ export const createApplePayController = (
     | 'appleCompleteMerchantValidation$'
     | 'appleCompletePayment$'
     | 'appleSessionError$'
+    | 'appleCancelSession$'
+    | 'appleCompleteSession$'
   >,
   version: 3 | 4 | 5
 ) => {
@@ -33,6 +35,11 @@ export const createApplePayController = (
       // handle payment authorization
       session.onpaymentauthorized = (event) => {
         subjectManager.applePayAuthorized$.next(event.payment.token)
+      }
+
+      // cancel the apple pay session
+      session.oncancel = () => {
+        subjectManager.appleCancelSession$.next()
       }
 
       // start the session
@@ -58,5 +65,6 @@ export const createApplePayController = (
     } else {
       session.completePayment(ApplePaySession.STATUS_FAILURE)
     }
+    subjectManager.appleCompleteSession$.next()
   })
 }

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -193,6 +193,12 @@ export function setup(setupConfig: SetupConfig): void {
   subjectManager.appleValidateMerchant$.subscribe((validationUrl) =>
     dispatch({ type: 'appleValidateMerchant', data: validationUrl })
   )
+  subjectManager.appleCancelSession$.subscribe(() =>
+    dispatch({ type: 'appleCancelSession' })
+  )
+  subjectManager.appleSessionError$.subscribe(() =>
+    dispatch({ type: 'appleSessionError' })
+  )
 
   window.addEventListener('message', messageHandler)
   window.addEventListener('message', apiMessageHandler)

--- a/packages/embed/src/subjects.ts
+++ b/packages/embed/src/subjects.ts
@@ -35,6 +35,8 @@ export const createSubjectManager = () => {
     appleCompletePayment$: createSubject<boolean>(),
     appleAbortSession$: createSubject(),
     appleSessionError$: createSubject(),
+    appleCancelSession$: createSubject(),
+    appleCompleteSession$: createSubject(),
   }
 
   subjects.formSubmit$.subscribe(() => {

--- a/packages/embed/src/utils/create-subject.ts
+++ b/packages/embed/src/utils/create-subject.ts
@@ -12,7 +12,8 @@ export const createSubject = <T = void>(initialValue?: T) => {
     },
     next: (nextValue: T) => {
       value = nextValue
-      subscribers.forEach((callbackFn) => callbackFn(value))
+      // setTimeout will ensure events are called async
+      subscribers.forEach((callbackFn) => setTimeout(callbackFn(value), 0))
     },
     value: () => {
       return value


### PR DESCRIPTION
Resolves issues around cancellation of the Apple Pay payment sheet.

## Release Notes
Dismissing Apple Pay previously left the checkout in a pending state when the user dismissed the payment sheet. This also resolves the issue of the transaction being completed before the payment sheet has closed.