### PR TITLE
fix: update async tests

### DIFF
--- a/packages/embed/src/form/form.test.ts
+++ b/packages/embed/src/form/form.test.ts
@@ -23,8 +23,15 @@ describe('createFormController', () => {
   })
 
   describe('onTransactionCreated', () => {
-    it('should inject the transaction id', () => {
+    beforeEach(() => {
       jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should inject the transaction id', () => {
       createFormController(form, null, subject)
       subject.transactionCreated$.next({ id: '123', status: 'captured' })
 
@@ -35,18 +42,15 @@ describe('createFormController', () => {
           'gr4vy_transaction_id'
         )[0] as HTMLInputElement).value
       ).toBe('123')
-      jest.useRealTimers()
     })
 
     it('should submit the form', (done) => {
-      jest.useFakeTimers()
       form.onsubmit = () => {
         done()
       }
       createFormController(form, null, subject)
       subject.transactionCreated$.next({ id: '123', status: 'captured' })
       jest.runAllTimers()
-      jest.useRealTimers()
     })
   })
 })

--- a/packages/embed/src/form/form.test.ts
+++ b/packages/embed/src/form/form.test.ts
@@ -24,21 +24,29 @@ describe('createFormController', () => {
 
   describe('onTransactionCreated', () => {
     it('should inject the transaction id', () => {
+      jest.useFakeTimers()
       createFormController(form, null, subject)
       subject.transactionCreated$.next({ id: '123', status: 'captured' })
+
+      jest.runAllTimers()
+
       expect(
         (document.getElementsByName(
           'gr4vy_transaction_id'
         )[0] as HTMLInputElement).value
       ).toBe('123')
+      jest.useRealTimers()
     })
 
     it('should submit the form', (done) => {
+      jest.useFakeTimers()
       form.onsubmit = () => {
         done()
       }
       createFormController(form, null, subject)
       subject.transactionCreated$.next({ id: '123', status: 'captured' })
+      jest.runAllTimers()
+      jest.useRealTimers()
     })
   })
 })

--- a/packages/embed/src/frame/frame.test.ts
+++ b/packages/embed/src/frame/frame.test.ts
@@ -25,6 +25,7 @@ describe('createFrameController', () => {
   })
 
   test('should change frame height when visible', () => {
+    jest.useFakeTimers()
     const iframeUrl = 'http://localhost:8000'
     const frameElement = document.createElement('iframe')
     createFrameController(frameElement, iframeUrl, subject)
@@ -32,7 +33,12 @@ describe('createFrameController', () => {
     frameElement.style.visibility = 'unset'
     expect(frameElement.style.height).toBe('0px')
     subject.frameHeight$.next(50)
+
+    jest.runAllTimers()
+
     expect(frameElement.style.height).toBe('50px')
+
+    jest.useRealTimers()
   })
 
   test('should not change frame height when hidden', () => {
@@ -47,12 +53,19 @@ describe('createFrameController', () => {
   })
 
   test('should show the iframe when options loaded', () => {
+    jest.useFakeTimers()
+
     const iframeUrl = 'http://localhost:8000'
     const frameElement = document.createElement('iframe')
     createFrameController(frameElement, iframeUrl, subject)
 
     subject.optionsLoaded$.next(true)
+
+    jest.runAllTimers()
+
     expect(frameElement.style.visibility).toBe('unset')
     expect(frameElement.style.display).toBe('unset')
+
+    jest.useRealTimers()
   })
 })

--- a/packages/embed/src/frame/frame.test.ts
+++ b/packages/embed/src/frame/frame.test.ts
@@ -1,6 +1,8 @@
 import { createSubjectManager, SubjectManager } from '../subjects'
 import { createFrameController } from './frame'
 
+jest.useFakeTimers()
+
 describe('createFrameController', () => {
   let subject: SubjectManager
 
@@ -25,7 +27,6 @@ describe('createFrameController', () => {
   })
 
   test('should change frame height when visible', () => {
-    jest.useFakeTimers()
     const iframeUrl = 'http://localhost:8000'
     const frameElement = document.createElement('iframe')
     createFrameController(frameElement, iframeUrl, subject)
@@ -37,8 +38,6 @@ describe('createFrameController', () => {
     jest.runAllTimers()
 
     expect(frameElement.style.height).toBe('50px')
-
-    jest.useRealTimers()
   })
 
   test('should not change frame height when hidden', () => {
@@ -53,8 +52,6 @@ describe('createFrameController', () => {
   })
 
   test('should show the iframe when options loaded', () => {
-    jest.useFakeTimers()
-
     const iframeUrl = 'http://localhost:8000'
     const frameElement = document.createElement('iframe')
     createFrameController(frameElement, iframeUrl, subject)
@@ -65,7 +62,5 @@ describe('createFrameController', () => {
 
     expect(frameElement.style.visibility).toBe('unset')
     expect(frameElement.style.display).toBe('unset')
-
-    jest.useRealTimers()
   })
 })

--- a/packages/embed/src/overlay/overlay.test.ts
+++ b/packages/embed/src/overlay/overlay.test.ts
@@ -1,6 +1,8 @@
 import { createSubjectManager } from '../subjects'
 import { createOverlayController } from './overlay'
 
+jest.useFakeTimers()
+
 describe('createOverlayController', () => {
   let subject
 
@@ -21,6 +23,9 @@ describe('createOverlayController', () => {
     })
     createOverlayController(overlay, subject)
     subject.approvalStarted$.next()
+
+    jest.runAllTimers()
+
     expect(overlay.className).toEqual('gr4vy__overlay gr4vy__overlay--visible')
   })
 
@@ -45,6 +50,9 @@ describe('createOverlayController', () => {
     overlay.className = 'gr4vy__overlay gr4vy__overlay--hidden'
     createOverlayController(overlay, subject)
     subject.approvalUrl$.next('https://approval.gr4vy.com')
+
+    jest.runAllTimers()
+
     expect(overlay.className).toEqual('gr4vy__overlay gr4vy__overlay--visible')
   })
 })

--- a/packages/embed/src/skeleton/skeleton.test.ts
+++ b/packages/embed/src/skeleton/skeleton.test.ts
@@ -1,6 +1,8 @@
 import { createSubjectManager } from '../subjects'
 import { createSkeletonController } from './skeleton'
 
+jest.useFakeTimers()
+
 describe('createSkeletonController', () => {
   it('should be removed when options have laoded', () => {
     const mockElement = {
@@ -9,6 +11,9 @@ describe('createSkeletonController', () => {
     const subject = createSubjectManager()
     createSkeletonController(mockElement, subject, undefined)
     subject.optionsLoaded$.next(true)
+
+    jest.runAllTimers()
+
     expect(mockElement.remove).toHaveBeenCalled()
   })
 })

--- a/packages/embed/src/subjects.test.ts
+++ b/packages/embed/src/subjects.test.ts
@@ -12,15 +12,17 @@ describe('createSubjectManager', () => {
     })
   })
 
-  test('should start approval if required on form submit', () => {
+  test('should start approval if required on form submit', (done) => {
     subject.mode$.next({})
-    let result = false
+
+    // assert
     const approvalStarted = subject.approvalStarted$.subscribe(() => {
-      result = true
+      approvalStarted.unsubscribe()
+      done()
     })
+
+    // act
     subject.formSubmit$.next()
-    approvalStarted.unsubscribe()
-    expect(result).toBe(true)
   })
 
   test('should skip approval if not required on form submit', () => {
@@ -33,23 +35,25 @@ describe('createSubjectManager', () => {
     expect(result).toBe(false)
   })
 
-  test('should complete approval on transaction complete', () => {
+  test('should complete approval on transaction complete', (done) => {
     subject.mode$.next({
       popup: {
         title: 'Test',
         message: 'Test Message',
       },
     })
-    let result = false
-    const approvalCompleted = subject.approvalCompleted$.subscribe(
-      () => (result = true)
-    )
+
+    // assert
+    const approvalCompleted = subject.approvalCompleted$.subscribe(() => {
+      approvalCompleted.unsubscribe()
+      done()
+    })
+
+    // act
     subject.transactionCreated$.next({
       id: 'test-transaction-id',
       status: 'captured',
     })
-    approvalCompleted.unsubscribe()
-    expect(result).toBe(true)
   })
 
   test('should skip complete approval if not required on transaction complete', () => {

--- a/packages/embed/src/utils/create-subject.ts
+++ b/packages/embed/src/utils/create-subject.ts
@@ -13,7 +13,9 @@ export const createSubject = <T = void>(initialValue?: T) => {
     next: (nextValue: T) => {
       value = nextValue
       // setTimeout will ensure events are called async
-      subscribers.forEach((callbackFn) => setTimeout(callbackFn(value), 0))
+      subscribers.forEach((callbackFn) =>
+        setTimeout(() => callbackFn(value), 0)
+      )
     },
     value: () => {
       return value


### PR DESCRIPTION
This was incorrect. (Albeit it had no effect). This wasn't doing the callback in a separate macro-task.
With it actually working - It meant a few tests needed to be updated to flush the macro-task queue with `jest.runAllTimers();` See https://jestjs.io/docs/timer-mocks#run-all-timers

**Before**
```subscribers.forEach((callbackFn) => setTimeout(callbackFn(value), 0))```

**After**
```
subscribers.forEach((callbackFn) => {
  setTimeout(callbackFn(value), 0)
})
```