### PR TITLE
refactor: remove prefer response

### DIFF
--- a/packages/embed-react/src/index.stories.tsx
+++ b/packages/embed-react/src/index.stories.tsx
@@ -7,13 +7,6 @@ export default {
   decorators: [withKnobs],
 }
 
-const responseOptions = {
-  '': ``,
-  '202 - Request accepted': `prefer: code=202, example=Request accepted`,
-  '400 - Incorrect JSON': `prefer: code=400, example=Incorrect JSON`,
-  '401 - Unauthorized request': `prefer: code=401, example=An unauthorized request`,
-}
-
 const currencyOptions = [`USD`, `GBP`, `EUR`]
 
 const intentOptions = [`capture`, `approve`, `auhtorize`]
@@ -50,12 +43,6 @@ export const Default = () => {
             ) as any
           }
           debug
-          preferResponse={select(
-            `Prefered server response`,
-            responseOptions,
-            ``,
-            `Development`
-          )}
         />
       )}
     </>

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -30,7 +30,6 @@ export const optionKeys = [
   'token',
   'debug',
   'externalIdentifier',
-  'preferResponse',
   'buyerId',
   'buyerExternalIdentifier',
   'environment',

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -8,7 +8,6 @@ export type Config = {
   debug?: boolean // wether to output any debug messages.
   onEvent?: (eventName: string, data: any) => void // a callback function that's used to subscribe to events
   externalIdentifier?: string // an optional external identifier
-  preferResponse?: string // a development option that allows sending a `Prefer` header to force a certain API response from dev servers
   buyerId?: string // the ID of the buyer to associate the payment methods to
   buyerExternalIdentifier?: string // the external ID of the buyer to associate the payment methods to
   environment?: 'development' | 'staging' | 'production'

--- a/packages/embed/src/validation.ts
+++ b/packages/embed/src/validation.ts
@@ -302,14 +302,6 @@ export const validate = (options: SetupConfig) =>
     callback: options.onEvent,
   }) &&
   validateType({
-    argument: 'preferResponse',
-    value: options.preferResponse,
-    type: 'string',
-    message: 'must be a string',
-    required: false,
-    callback: options.onEvent,
-  }) &&
-  validateType({
     argument: 'externalIdentifier',
     value: options.externalIdentifier,
     type: 'string',


### PR DESCRIPTION
This is no longer used (mainly for internal development). This was never documented as something that you could do in Embed so marking it as an internal/minor change.