### PR TITLE
feat: add custom options

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "glob-parent": "^6.0.1",
     "browserslist": "^4.16.5",
     "prismjs": "~1.25.0",
-    "tmpl": "~1.0.5"
+    "tmpl": "~1.0.5",
+    "json-schema": "0.4.0"
   }
 }

--- a/packages/embed-react/README.md
+++ b/packages/embed-react/README.md
@@ -73,6 +73,8 @@ The options for this integration are as follows.
 | `token`                   | `null`      | **Required** - The server-side generated JWT token used to authenticate any of the API calls.                                                                                                                                                        |
 | `onComplete`              | `null`      | Callback with a transaction object. (Form submission must be handled manually)                                                                                                                                                                       |
 | `display`                 | `all`       | `all`, `addOnly`, `storedOnly`, `supportsTokenization` - Filters the payment methods to show stored methods only, new payment methods only or methods that support tokenization.                                                                     |
+| `customOptions`           | `null`      | List of custom options. e.g. `[{ label: 'Giftcard', method: 'giftcard', description: 'You will be asked for a giftcard code.', iconUrl: 'data:image/svg+xml,...'}]`                                                                                  |
+| `onCustomSubmit`          | `null`      | Callback when a custom payment option is selected and the form submitted.                                                                                                                                                                            |
 
 ### Events
 
@@ -151,6 +153,29 @@ Embed will automatically submit the payment form with hidden inputs, this can be
   onEvent={(name, data) => {...}}
   onComplete={(transaction) => {
     // Handle custom form submission
+  }}
+/>
+```
+
+## Custom Options
+
+Embed will render custom payment options if you need to integrate with existing checkouts. This will not trigger any processing by
+embed and instead you will need to handle the form submission.
+
+```tsx
+<Gr4vyEmbed
+  // Provide a list of custom options
+  customOptions={[
+    {
+      label: 'Giftcard',
+      method: 'giftcard', // This should be a unique identifier for your custom option
+      description: 'You will be asked to enter a giftcard',
+      iconUrl: `data:image/svg+xml,...`, // This should be a data:image/svg+xml url
+    }
+  ]}
+  // Handle the submit for a custom option
+  onCustomSubmit={({ method: 'giftcard' }) => {
+    console.log(`Paid by ${method}`);
   }}
 />
 ```

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -77,6 +77,8 @@ The options for this integration are as follows.
 | `token`                   | `null`      | **Required** - The server-side generated JWT token used to authenticate any of the API calls.                                                                                                                                                                                       |
 | `onComplete`              | `null`      | Callback with a transaction object. (Form submission must be handled manually)                                                                                                                                                                                                      |
 | `display`                 | `all`       | `all`, `addOnly`, `storedOnly`, `supportsTokenization` - Filters the payment methods to show stored methods only, new payment methods only or methods that support tokenization.                                                                                                    |
+| `customOptions`           | `null`      | List of custom options. e.g. `[{ label: 'Giftcard', method: 'giftcard', description: 'You will be asked for a giftcard code.', iconUrl: 'data:image/svg+xml,...'}]`                                                                                                                 |
+| `onCustomSubmit`          | `null`      | Callback when a custom payment option is selected and the form submitted.                                                                                                                                                                                                           |
 
 ### Theming
 
@@ -170,6 +172,29 @@ setup({
   }
 })
 
+```
+
+## Custom Options
+
+Embed will render custom payment options if you need to integrate with existing checkouts. This will not trigger any processing by
+embed and instead you will need to handle the form submission.
+
+```ts
+setup({
+  // Provide a list of custom options
+  customOptions: [
+    {
+      label: 'Giftcard',
+      method: 'giftcard', // This should be a unique identifier for your custom option
+      description: 'You will be asked to enter a giftcard',
+      iconUrl: `data:image/svg+xml,...`, // This should be a data:image/svg+xml url
+    }
+  ],
+  // Handle the submit for a custom option
+  onCustomSubmit: ({ method: 'giftcard' }) => {
+    console.log(`Paid by ${method}`);
+  }
+})
 ```
 
 ## License

--- a/packages/embed/src/form/form.test.ts
+++ b/packages/embed/src/form/form.test.ts
@@ -15,7 +15,7 @@ describe('createFormController', () => {
   })
 
   it('should hijack the form and notify formSubmit$', (done) => {
-    createFormController(form, null, subject)
+    createFormController(form, null, subject, null)
     subject.formSubmit$.subscribe(() => {
       done()
     })
@@ -32,7 +32,7 @@ describe('createFormController', () => {
     })
 
     it('should inject the transaction id', () => {
-      createFormController(form, null, subject)
+      createFormController(form, null, subject, null)
       subject.transactionCreated$.next({ id: '123', status: 'captured' })
 
       jest.runAllTimers()
@@ -48,7 +48,7 @@ describe('createFormController', () => {
       form.onsubmit = () => {
         done()
       }
-      createFormController(form, null, subject)
+      createFormController(form, null, subject, null)
       subject.transactionCreated$.next({ id: '123', status: 'captured' })
       jest.runAllTimers()
     })

--- a/packages/embed/src/form/form.ts
+++ b/packages/embed/src/form/form.ts
@@ -14,7 +14,8 @@ let instanceCount = 0
 export const createFormController = (
   form: HTMLFormElement,
   onComplete: CallableFunction,
-  subject: SubjectManager
+  subject: SubjectManager,
+  onCustomSubmit: CallableFunction
 ) => {
   // Check if currently managed by form napper
   if (parseInt(form.dataset.formNapperId) > 0) {
@@ -33,7 +34,11 @@ export const createFormController = (
   instances.set(instanceCount.toString(), formNapperInstance)
 
   formNapperInstance.hijack(() => {
-    subject.formSubmit$.next()
+    if (subject.selectedOption$.value()?.mode === 'custom') {
+      onCustomSubmit({ method: subject.selectedOption$.value().method })
+    } else {
+      subject.formSubmit$.next()
+    }
   })
 
   subject.transactionCreated$.subscribe((transaction) => {

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -39,6 +39,7 @@ export const optionKeys = [
   'locale',
   'display',
   'apiUrl',
+  'customOptions',
 ]
 
 // Map of cleanup callbacks
@@ -90,7 +91,8 @@ export function setup(setupConfig: SetupConfig): void {
   createFormController(
     config.form as HTMLFormElement,
     config.onComplete,
-    subjectManager
+    subjectManager,
+    config.onCustomSubmit
   )
 
   createPopupController(
@@ -136,6 +138,7 @@ export function setup(setupConfig: SetupConfig): void {
           supportedApplePayVersion,
         },
       }),
+    paymentMethodSelected: subjectManager.selectedOption$.next,
   }
 
   const dispatch = createDispatch(

--- a/packages/embed/src/subjects.ts
+++ b/packages/embed/src/subjects.ts
@@ -37,6 +37,10 @@ export const createSubjectManager = () => {
     appleSessionError$: createSubject(),
     appleCancelSession$: createSubject(),
     appleCompleteSession$: createSubject(),
+    selectedOption$: createSubject<{
+      mode?: string
+      method: string
+    }>(),
   }
 
   subjects.formSubmit$.subscribe(() => {

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -23,6 +23,15 @@ export type Config = {
   onComplete?: (transaction: Transaction) => void
   channel: string
   iframeSrc: string
+  customOptions?: Array<CustomOption>
+  onCustomSubmit?: ({ method }) => void
+}
+
+export type CustomOption = {
+  method: string
+  label: string
+  description: string
+  iconUrl: string
 }
 
 export type Transaction = {
@@ -195,5 +204,12 @@ export type Message = { channel: string; data?: unknown } & (
   | {
       type: 'appleStartSession'
       data: ApplePayJS.ApplePayPaymentRequest
+    }
+  | {
+      type: 'paymentMethodSelected'
+      data: {
+        method: string
+        mode?: string
+      }
     }
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -9944,10 +9944,10 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+json-schema@0.2.3, json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Allows you to add custom options to Embed that will be processed outside of Gr4vy.

```tsx
<Gr4vyEmbed
  // Provide a list of custom options
  customOptions={[
    {
      label: 'Giftcard',
      method: 'giftcard',
      description: 'You will be asked to enter a giftcard',
      iconUrl: `data:image/svg+xml,...`,
    }
  ]}

  // Handle the submit for a custom option
  onCustomSubmit={({ method: 'giftcard' }) => {
    alert(`Paid by ${method}`);
  }}
/>
```

![2021-12-14 11 47 18](https://user-images.githubusercontent.com/1008377/145996751-423d3b91-f37b-469b-be3d-684dd996d2bb.gif)
