### PR TITLE
fix: embed does not re-render when props change

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -29,6 +29,7 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
+    "lodash.isequal": "^4.5.0",
     "@gr4vy/embed": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/embed-react/src/Gr4vyEmbed.tsx
+++ b/packages/embed-react/src/Gr4vyEmbed.tsx
@@ -1,10 +1,11 @@
 import { setup } from '@gr4vy/embed'
 import { SetupConfig } from '@gr4vy/embed/lib/types'
-import React, { useRef, useEffect } from 'react'
+import isEqual from 'lodash.isequal'
+import React, { useRef, useEffect, memo } from 'react'
 
 export type Gr4vyEmbedProps = Omit<SetupConfig, 'element'>
 
-const Gr4vyEmbed = (props: Gr4vyEmbedProps) => {
+const Gr4vyEmbed = memo((props: Gr4vyEmbedProps) => {
   const ref = useRef()
 
   useEffect(() => {
@@ -14,10 +15,10 @@ const Gr4vyEmbed = (props: Gr4vyEmbedProps) => {
         element: ref.current,
       })
     }
-  }, [ref])
+  }, [ref, props])
 
   return <div ref={ref} />
-}
+}, isEqual)
 
 Gr4vyEmbed.displayName = 'Gr4vyEmbed'
 

--- a/packages/embed-react/src/index.stories.tsx
+++ b/packages/embed-react/src/index.stories.tsx
@@ -9,13 +9,16 @@ export default {
 
 const currencyOptions = [`USD`, `GBP`, `EUR`]
 
-const intentOptions = [`capture`, `approve`, `auhtorize`]
+const intentOptions = [`capture`, `approve`]
 
 const environmentOptions = ['production', 'sandbox']
 
-export const Default = () => {
+const Template = ({ showRenderControls = false }) => {
   const form = useRef<HTMLFormElement>()
   const [formReady, setFormReady] = useState(false)
+  const [amount, setAmount] = useState(number(`Amount`, 1299, {}, `Public`))
+  const [count, setCount] = useState(1)
+  const [color, setColor] = useState('green')
 
   useEffect(() => {
     setFormReady(true)
@@ -23,17 +26,38 @@ export const Default = () => {
 
   return (
     <>
+      {showRenderControls && (
+        <>
+          <button onClick={() => setAmount(amount + 1)}>Increase amount</button>
+          <button onClick={() => setCount(count + 1)}>Increase count</button>
+          <button
+            onClick={() =>
+              setColor(`#${Math.floor(Math.random() * 16777215).toString(16)}`)
+            }
+          >
+            Update theme color
+          </button>
+          <p>Amount: {amount} (Rerender)</p>
+          <p>Count: {count}</p>
+          <p>Color: {color} (Rerender)</p>
+        </>
+      )}
       <form ref={form} />
       {formReady && (
         <Gr4vyEmbed
           form={form.current}
-          amount={number(`Amount`, 1299, {}, `Public`)}
+          amount={amount}
           intent={select(`Intent`, intentOptions, 'capture', `Public`) as any}
           currency={select(`Currency`, currencyOptions, `USD`, `Public`)}
           apiHost={text(`API host`, `127.0.0.1:3100`, `Public`)}
           iframeHost={text(`iFrame host`, `127.0.0.1:8082`, `Public`)}
           token={text(`JWT token`, `1234567`, `Public`)}
           country="US"
+          theme={{
+            colors: {
+              primary: color,
+            },
+          }}
           environment={
             select(
               `Environment`,
@@ -47,4 +71,12 @@ export const Default = () => {
       )}
     </>
   )
+}
+
+export const Default = () => <Template />
+
+export const RenderTest = () => <Template showRenderControls={true} />
+
+RenderTest.parameters = {
+  storyshots: { disable: true },
 }


### PR DESCRIPTION
Adds memoization for prop-changes - React will do a shallow compare, but this does a deep comparison to see whats changed. We could optimise later on to just pass-through changes.

<img src="https://user-images.githubusercontent.com/1008377/146340868-b230da53-d51b-44db-a98b-fd924254d5ea.gif" width=50% height=50%>

## Release Notes

Embed React will now re-render on prop changes. This uses React `memo` with a deep comparison of props so nested objects, such as `theme` will still cause a re-render if changed.