### PR TITLE
Radio input theme support

### DIFF
--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -104,6 +104,8 @@ export type ThemeOptions = {
     inputBorder?: string
     inputText?: string
     inputBackground?: string
+    inputRadioBorder?: string
+    inputRadioBorderChecked?: string
     /**
      * Info is used for loading bars or displaying information.
      */


### PR DESCRIPTION
## Release notes

Adds support for theming radio inputs using `inputRadioBorder` and `inputRadioBorderChecked`, if these are not defined the previous default values will be used (no visual breaking changes).