### PR TITLE
Support for transactionFailed event when using onEvent

### DIFF
--- a/packages/embed-react/README.md
+++ b/packages/embed-react/README.md
@@ -138,7 +138,9 @@ is valid.
 
 #### `transactionCreated`
 
-Returns a full transaction object when the transaction was successfully created.
+Returns a full transaction object when Gr4vy accepted the transaction,
+regardless of its status. Be aware that this can be a pending or declined
+transaction. To track API failures please use the `transactionFailed` event.
 
 ```json
 {
@@ -162,7 +164,14 @@ and should not be conflated with transaction being declined or an error occuring
 
 #### `transactionFailed`
 
-Returned when an api call fails to create a transaction, this would only be raised for a status code of 4xx or 5xx.
+Returned when an API call fails to create a transaction due to a client or
+server error. In other words, this event is raised when incorrect data (like an
+invalid JWT) is passed to the Gr4vy API and a HTTP status code in the `4XX` or
+`5XX` range is returned.
+
+To catch failed or declined transactions due to
+downstream issues with the payment service, please subscribe to the
+`transactionCreated` event.
 
 ```json
 {

--- a/packages/embed-react/README.md
+++ b/packages/embed-react/README.md
@@ -159,6 +159,19 @@ and should not be conflated with transaction being declined or an error occuring
 }
 ```
 
+#### `transactionFailed`
+
+Returned when an api call fails to create a transaction.
+
+```json
+{
+  "type": "error",
+  "code": "unauthorized",
+  "status": 401,
+  "message": "No valid API authentication found"
+}
+```
+
 #### `apiError`
 
 Returned when the form encounters an API error.

--- a/packages/embed-react/README.md
+++ b/packages/embed-react/README.md
@@ -162,7 +162,7 @@ and should not be conflated with transaction being declined or an error occuring
 
 #### `transactionFailed`
 
-Returned when an api call fails to create a transaction.
+Returned when an api call fails to create a transaction, this would only be raised for a status code of 4xx or 5xx.
 
 ```json
 {

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -180,7 +180,7 @@ and should not be conflated with transaction being declined or an error occuring
 
 #### `transactionFailed`
 
-Returned when an api call fails to create a transaction.
+Returned when an api call fails to create a transaction, this would only be raised for a status code of 4xx or 5xx.
 
 ```json
 {

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -156,7 +156,9 @@ is valid.
 
 #### `transactionCreated`
 
-Returns a full transaction object when the transaction was successfully created.
+Returns a full transaction object when Gr4vy accepted the transaction,
+regardless of its status. Be aware that this can be a pending or declined
+transaction. To track API failures please use the `transactionFailed` event.
 
 ```json
 {
@@ -180,7 +182,14 @@ and should not be conflated with transaction being declined or an error occuring
 
 #### `transactionFailed`
 
-Returned when an api call fails to create a transaction, this would only be raised for a status code of 4xx or 5xx.
+Returned when an API call fails to create a transaction due to a client or
+server error. In other words, this event is raised when incorrect data (like an
+invalid JWT) is passed to the Gr4vy API and a HTTP status code in the `4XX` or
+`5XX` range is returned.
+
+To catch failed or declined transactions due to
+downstream issues with the payment service, please subscribe to the
+`transactionCreated` event.
 
 ```json
 {

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -177,6 +177,19 @@ and should not be conflated with transaction being declined or an error occuring
 }
 ```
 
+#### `transactionFailed`
+
+Returned when an api call fails to create a transaction.
+
+```json
+{
+  "type": "error",
+  "code": "unauthorized",
+  "status": 401,
+  "message": "No valid API authentication found"
+}
+```
+
 #### `apiError`
 
 Returned when the form encounters an API error.

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -168,6 +168,7 @@ export function setup(setupConfig: SetupConfig): EmbedInstance {
         [
           'formUpdate',
           'transactionCreated',
+          'transactionFailed',
           'apiError',
           'paymentMethodSelected',
           'transactionCancelled',

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -179,6 +179,15 @@ export type Message = { channel: string; data?: unknown } & (
       }
     }
   | {
+      type: 'transactionFailed'
+      data: {
+        code: number
+        message?: string
+        status?: string
+        type?: string
+      }
+    }
+  | {
       type: 'frameReady'
     }
   | {


### PR DESCRIPTION
Passes through the `transactionFailed` events to `onEvent` - It's not super clear what all the possible return error types are from https://gr4vy.com/docs/reference#operation/authorize-new-transaction

💡 We could potentially look at using `type import` https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html and get these values from the SDK in future.