### PR TITLE
deploy commit sha [skip ci]

### DIFF
--- a/cloudbuild/cloudbuild-cdn.yaml
+++ b/cloudbuild/cloudbuild-cdn.yaml
@@ -92,7 +92,7 @@ steps:
           curl \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token $$GITHUB_TOKEN" \
-            -d '{"ref":"main","environment":"spider-sandbox","auto_merge":false,"required_contexts":[],"payload":{"substitutions":{"region":"us-central1"},"config_path":"cloudbuild/deploy-env.yaml"}}' \
+            -d '{"ref":"${COMMIT_SHA}","environment":"spider-sandbox","auto_merge":false,"required_contexts":[],"payload":{"substitutions":{"region":"us-central1"},"config_path":"cloudbuild/deploy-env.yaml"}}' \
             https://api.github.com/repos/gr4vy/${REPO_NAME}/deployments
         else
           echo "This is the ${BRANCH_NAME} branch. Not deploying to spider-sandbox."
@@ -111,7 +111,7 @@ steps:
           curl \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token $$GITHUB_TOKEN" \
-            -d '{"ref":"main","environment":"spider-production","auto_merge":false,"required_contexts":[],"payload":{"substitutions":{"region":"us-central1"},"config_path":"cloudbuild/deploy-env.yaml"}}' \
+            -d '{"ref":"${COMMIT_SHA}","environment":"spider-production","auto_merge":false,"required_contexts":[],"payload":{"substitutions":{"region":"us-central1"},"config_path":"cloudbuild/deploy-env.yaml"}}' \
             https://api.github.com/repos/gr4vy/${REPO_NAME}/deployments
         else
           echo "This is the ${BRANCH_NAME} branch. Not deploying to spider-production."


### PR DESCRIPTION
# Description

The Cloud Build step to deploy the service always uses the [`main` reference](https://github.com/gr4vy/gr4vy-embed/blob/c9599e7dafe2f4ed471534b20fa4b498b0358565/cloudbuild/cloudbuild-cdn.yaml#L95) when calling the GitHub deployment API.

We recently saw a number of service deployments to `spider` fail because the container couldn't be found. This happened because there had been another commit to the main branch before the request to the GitHub deployment API was made.

This PR changes the request to the GitHub deployment API to use the commit SHA as the reference, ensuring we deploy the container built in the previous step.


