### PR TITLE
Deploy during shared LB migration [PE-128]

### DIFF
--- a/cloudbuild/deploy-env.yaml
+++ b/cloudbuild/deploy-env.yaml
@@ -14,17 +14,26 @@ steps:
 
   - id: 'Invalidate CDN cache'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
-    entrypoint: ash
+    entrypoint: bash
     args:
+      - '-eEuo'
+      - pipefail
       - '-c'
-      - >-
+      - |-
         gcloud compute url-maps invalidate-cdn-cache $_URL_MAP --path='/*' --async --project $PROJECT_ID
+
+        if [ ${_GR4VY_ENV} = "production" ]; then
+          gcloud compute url-maps invalidate-cdn-cache $_URL_MAP_SHARED --host='cdn.${_GR4VY_ID}.gr4vy.app' --path='/*' --async --project $PROJECT_ID || true
+        else
+          gcloud compute url-maps invalidate-cdn-cache $_URL_MAP_SHARED --host='cdn.${_GR4VY_ENV}.${_GR4VY_ID}.gr4vy.app' --path='/*' --async --project $PROJECT_ID || true
+        fi
 
 substitutions:
   _GR4VY_ID: ${PROJECT_ID%-*}
   _GR4VY_ENV: 'sandbox'
   _ARTIFACT_STORAGE_BUCKET: embed-cdn-${_GR4VY_ENV}-${_GR4VY_ID}-gr4vy-app
   _URL_MAP: embed-cdn-${_GR4VY_ENV}-${_GR4VY_ID}-gr4vy-app-url-map
+  _URL_MAP_SHARED: ${_GR4VY_ID}-${_GR4VY_ENV}-url-map
 
 options:
   dynamic_substitutions: true


### PR DESCRIPTION
Amending the deployment step related to cache invalidation to prepare for the introduction of a shared HTTPS load balancer.

The command to invalidate the cache on the new load balancer will not fail the deployment if it’s unable to complete, allowing us to introduce the new shared load balancers without interrupting deployments.