### PR TITLE
feat: explicitly log authentication errors as warnings

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -14,6 +14,9 @@ CVE-2021-23382
 GHSA-5rrq-pxf6-6jx5
 GHSA-gf8q-jrpm-jvxq
 CVE-2022-0122
+CVE-2022-24771
+CVE-2022-24772
+CVE-2022-24773
 
 # node-fetch - Dev Dependency
 CVE-2022-0235

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "json-schema": "0.4.0",
     "ansi-html": ">=0.0.8",
     "follow-redirects": ">=1.14.8",
-    "url-parse": ">=1.5.9"
+    "url-parse": ">=1.5.9",
+    "minimist": "^1.2.6"
   }
 }

--- a/packages/embed/src/create-config.test.ts
+++ b/packages/embed/src/create-config.test.ts
@@ -59,6 +59,8 @@ test('default configuration', () => {
     iframeSrc: `https://embed.test.gr4vy.app/?parentUrl=https%3A%2F%2Ftest.com&channel=${CHANNEL_ID}`,
     store: 'ask',
     token: '123',
+    environment: undefined,
+    gr4vyId: 'test',
   })
 })
 

--- a/packages/embed/src/create-config.ts
+++ b/packages/embed/src/create-config.ts
@@ -28,6 +28,7 @@ export const createConfig = (setupConfig: SetupConfig) => {
     display: 'all',
     apiHost,
     apiUrl: hostToUrl(apiHost),
+    gr4vyId,
     iframeHost,
     iframeUrl,
     iframeSrc: appendUrlParams(iframeUrl, {

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -28,6 +28,7 @@ export const optionKeys = [
   'currency',
   'intent',
   'apiHost',
+  'gr4vyId',
   'token',
   'debug',
   'externalIdentifier',

--- a/packages/embed/src/utils/pick.test.ts
+++ b/packages/embed/src/utils/pick.test.ts
@@ -8,4 +8,13 @@ describe('pick', () => {
     }
     expect(pick(options, ['foo'])).toEqual({ foo: 'bar' })
   })
+
+  test(`should not include keys with nullish values`, () => {
+    const options = {
+      foo: 'bar',
+      bar: undefined,
+      baz: null,
+    }
+    expect(pick(options, ['foo', 'bar', 'baz'])).toEqual({ foo: 'bar' })
+  })
 })

--- a/packages/embed/src/utils/pick.ts
+++ b/packages/embed/src/utils/pick.ts
@@ -1,5 +1,7 @@
 export const pick = <T>(object: Object, keys: Array<string>) =>
   keys.reduce((newObject, key) => {
-    newObject[key] = object[key]
+    if (object[key]) {
+      newObject[key] = object[key]
+    }
     return newObject
   }, {}) as T

--- a/yarn.lock
+++ b/yarn.lock
@@ -10762,10 +10762,10 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
**Description:** Adds `gr4vyId` to the options object passed to the embed, for debugging purposes.

**Ticket:** https://gr4vy.atlassian.net/browse/TA-1026

**Screenshot(s):**

![Screenshot 2022-03-21 at 17 28 41](https://user-images.githubusercontent.com/101414321/159519684-dbc7e994-2c3f-419b-b782-f5a61850d89f.png)
