### PR TITLE
Fix "save cache" Cloud Build step [PE-219]

### DIFF
--- a/cloudbuild/cloudbuild-cdn.yaml
+++ b/cloudbuild/cloudbuild-cdn.yaml
@@ -73,7 +73,7 @@ steps:
     name: gcr.io/${PROJECT_ID}/save_cache
     args:
       [
-        '--bucket=gs://${_CACHE_BUCKET}/',
+        '--bucket=gs://${_CACHE_BUCKET}',
         '--key=node_modules-$( checksum yarn.lock )',
         '--path=node_modules',
         '--no-clobber',


### PR DESCRIPTION

The Cloud Build step "" was always compressing and uploading the `node_modules` directory, even when the `yarn.lock` file hadn't changed.

```
gcr.io/gr4vy-admin/save_cache:latest
CommandException: One or more URLs matched no objects.
Compressing cache to ./node_modules-2636734882.tgz...
Uploading cache to Google Cloud Storage...
Copying file://./node_modules-2636734882.tgz [Content-Type=application/x-tar]...
/ [0 files][    0.0 B/  2.3 GiB]                                                
Operation completed over 1 objects/2.3 GiB.
```

The check that the save_cache builder does already adds a slash when constructing the gsutil command to run:
https://github.com/GoogleCloudPlatform/cloud-builders-community/blob/master/cache/save_cache#L78

This meant that we were searching for an object with a double slash, which was never found.

Removing the trailing slash from the `--bucket` option solves this issue.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>