### PR TITLE
Fix window.gr4vy.version declaration

### DIFF
--- a/packages/embed/src/utils/version.ts
+++ b/packages/embed/src/utils/version.ts
@@ -15,5 +15,5 @@ export const setVersion = (pkg: Package, ver = PACKAGE_VERSION) => {
     window.gr4vy = { version: {} }
   }
 
-  window.gr4vy.version[pkg] = ver
+  window.gr4vy.version = { [pkg]: ver }
 }


### PR DESCRIPTION
**Description:** When using the cdn version of embed, there's a `window.gr4vy` object already but `version` is not defined, causing an error when trying to set the version from there. This fixes it.

