### PR TITLE
fix: embed version doesn't display anymore

### DIFF
--- a/packages/embed/src/utils/version.ts
+++ b/packages/embed/src/utils/version.ts
@@ -15,5 +15,9 @@ export const setVersion = (pkg: Package, ver = PACKAGE_VERSION) => {
     window.gr4vy = { version: {} }
   }
 
-  window.gr4vy.version = { [pkg]: ver }
+  if (!window.gr4vy.version) {
+    window.gr4vy.version = {}
+  }
+
+  window.gr4vy.version[pkg] = ver
 }


### PR DESCRIPTION
**Description:** We pushed a hotfix https://github.com/gr4vy/gr4vy-embed/pull/86 for a production error, but the `embed` version stopped displaying. This fixes it, and makes sure that error doesn't surface anymore. Tested with both `embed/react` and `embed/cdn`

**Ticket:** https://gr4vy.atlassian.net/browse/TA-1466