### PR TITLE
Add allow-popups and allow-top-navigation to sandboxed iframe

### DIFF
--- a/packages/embed/src/frame/frame.test.ts
+++ b/packages/embed/src/frame/frame.test.ts
@@ -25,7 +25,7 @@ describe('createFrameController', () => {
     expect(frameElement.getAttribute('frameBorder')).toEqual('0')
     expect(frameElement.getAttribute('scrolling')).toEqual('no')
     expect(frameElement.getAttribute('sandbox')).toEqual(
-      'allow-forms allow-same-origin allow-scripts'
+      'allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation'
     )
   })
 

--- a/packages/embed/src/frame/frame.ts
+++ b/packages/embed/src/frame/frame.ts
@@ -23,7 +23,10 @@ export const createFrameController = (
   frame.setAttribute('allowpaymentrequest', 'true')
 
   // security
-  frame.setAttribute('sandbox', 'allow-forms allow-same-origin allow-scripts')
+  frame.setAttribute(
+    'sandbox',
+    'allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation'
+  )
 
   subject.frameHeight$.subscribe((height) => {
     if (frame.style.visibility === 'unset') {

--- a/packages/embed/src/overlay/overlay.ts
+++ b/packages/embed/src/overlay/overlay.ts
@@ -62,7 +62,7 @@ export const createOverlayController = (
         frameborder="0"
         class="gr4vy__frame"
         allowtransparency="true"
-        sandbox="allow-forms allow-popups allow-same-origin allow-scripts"
+        sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation"
       ></iframe>
     `
   }


### PR DESCRIPTION
**Description:** Fixes an issue where Google Pay might not get launched properly on browsers other than Chrome (Brave, Firefox..), due to restrictions we recently added to our iframes.

**Ticket:** https://gr4vy.atlassian.net/browse/TA-1687

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.11.5--canary.89.056cbba.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @gr4vy/embed-react@2.11.5--canary.89.056cbba.0
  npm install @gr4vy/embed@2.11.5--canary.89.056cbba.0
  # or 
  yarn add @gr4vy/embed-react@2.11.5--canary.89.056cbba.0
  yarn add @gr4vy/embed@2.11.5--canary.89.056cbba.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
