### PR TITLE
test: add test for embed cdn

### DIFF
--- a/packages/example-cdn/index.test.ts
+++ b/packages/example-cdn/index.test.ts
@@ -24,7 +24,7 @@ test('embed is able to load on the page', async ({ page }) => {
            * to start receiving messages.
            */
           window.parent.postMessage(
-            { type: 'frameReady', channel },
+            { type: 'frameReady', channel, data: { version: 123 } },
             parentOrigin
           )
 

--- a/packages/example-cdn/index.test.ts
+++ b/packages/example-cdn/index.test.ts
@@ -3,7 +3,12 @@ import { test, expect } from '@playwright/test'
 const html = String.raw
 
 test('embed is able to load on the page', async ({ page }) => {
+  // arrange
   await page.route('https://embed.demo.gr4vy.app/*', (route) => {
+    /*
+     * Return a mock page of embed ui, this will send the initial
+     * post messages required to display Embed.
+     */
     return route.fulfill({
       status: 200,
       contentType: 'text/html',
@@ -14,11 +19,19 @@ test('embed is able to load on the page', async ({ page }) => {
           const parentOrigin = new URL(parentUrl).origin
           const channel = href.searchParams.get('channel')
 
+          /*
+           * Send a message to Gr4vy Embed to communicate Embed UI is ready
+           * to start receiving messages.
+           */
           window.parent.postMessage(
             { type: 'frameReady', channel },
             parentOrigin
           )
 
+          /*
+           * Listen to messages coming from Gr4vy Embed. When the initial set of
+           * options have been received send a reply to indicate Embed UI has loaded.
+           */
           window.addEventListener('message', ({ data: message }) => {
             if (message?.type === 'updateOptions') {
               window.parent.postMessage(
@@ -29,7 +42,8 @@ test('embed is able to load on the page', async ({ page }) => {
                 { type: 'resize', channel, data: { frame: { height: 100 } } },
                 parentOrigin
               )
-              document.write('Success')
+
+              document.write('Success') // write to the page so that it can be used to assert
             }
           })
         </script>
@@ -37,13 +51,14 @@ test('embed is able to load on the page', async ({ page }) => {
     })
   })
 
+  // act
   await page.goto('/example-cdn')
 
+  // assert
   const iframe = page.frameLocator('iframe').locator('body')
-
   await expect(await iframe.innerText()).toBe('Success')
   await expect(await page.locator('.gr4vy__skeleton')).not.toBeVisible()
   await expect(await (await page.locator('iframe').boundingBox()).height).toBe(
     100
-  )
+  ) // ensure the height of the iframe has been changed
 })

--- a/packages/example-cdn/index.test.ts
+++ b/packages/example-cdn/index.test.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+
+const html = String.raw
+
+test('embed is able to load on the page', async ({ page }) => {
+  await page.route('https://embed.demo.gr4vy.app/*', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: html`<html>
+        <script>
+          const href = new URL(document.location.href)
+          const parentUrl = href.searchParams.get('parentUrl')
+          const parentOrigin = new URL(parentUrl).origin
+          const channel = href.searchParams.get('channel')
+
+          window.parent.postMessage(
+            { type: 'frameReady', channel },
+            parentOrigin
+          )
+
+          window.addEventListener('message', ({ data: message }) => {
+            if (message?.type === 'updateOptions') {
+              window.parent.postMessage(
+                { type: 'optionsLoaded', channel },
+                parentOrigin
+              )
+              window.parent.postMessage(
+                { type: 'resize', channel, data: { frame: { height: 100 } } },
+                parentOrigin
+              )
+              document.write('Success')
+            }
+          })
+        </script>
+      </html>`,
+    })
+  })
+
+  await page.goto('/example-cdn')
+
+  const iframe = page.frameLocator('iframe').locator('body')
+
+  await expect(await iframe.innerText()).toBe('Success')
+  await expect(await page.locator('.gr4vy__skeleton')).not.toBeVisible()
+  await expect(await (await page.locator('iframe').boundingBox()).height).toBe(
+    100
+  )
+})

--- a/packages/example-cdn/package.json
+++ b/packages/example-cdn/package.json
@@ -10,9 +10,15 @@
   "homepage": "https://gr4vy.com",
   "scripts": {
     "start": "http-server .. -o -p 9000",
-    "prepack": "echo 'This is a private project and should not be packed.'; exit 1;"
+    "start:ci": "http-server .. -p 9000",
+    "prepack": "echo 'This is a private project and should not be packed.'; exit 1;",
+    "test": "playwright test"
   },
   "dependencies": {
     "@gr4vy/embed": "^2.11.6"
+  },
+  "devDependencies": {
+    "playwright": "^1.22.2",
+    "@playwright/test": "latest"
   }
 }

--- a/packages/example-cdn/playwright.config.ts
+++ b/packages/example-cdn/playwright.config.ts
@@ -1,0 +1,14 @@
+import { PlaywrightTestConfig } from '@playwright/test'
+
+const config: PlaywrightTestConfig = {
+  timeout: 70000,
+  webServer: {
+    command: 'yarn start:ci',
+    url: 'http://localhost:9000',
+    timeout: 120 * 1000,
+  },
+  use: {
+    baseURL: 'http://localhost:9000',
+  },
+}
+export default config

--- a/yarn.lock
+++ b/yarn.lock
@@ -2550,6 +2550,14 @@
     tslib "^2.0.3"
     webcrypto-core "^1.1.8"
 
+"@playwright/test@latest":
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.22.2.tgz#b848f25f8918140c2d0bae8e9227a40198f2dd4a"
+  integrity sha512-cCl96BEBGPtptFz7C2FOSN3PrTnJ3rPpENe+gYCMx4GNNDlN4tmo2D89y13feGKTMMAIVrXfSQ/UmaQKLy1XLA==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.22.2"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
@@ -12122,6 +12130,18 @@ pkg-up@3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+playwright-core@1.22.2:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.22.2.tgz#ed2963d79d71c2a18d5a6fd25b60b9f0a344661a"
+  integrity sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==
+
+playwright@^1.22.2:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.22.2.tgz#353a7c29f89ca9600edc7a9a30aed790823c797d"
+  integrity sha512-hUTpg7LytIl3/O4t0AQJS1V6hWsaSY5uZ7w1oCC8r3a1AQN5d6otIdCkiB3cbzgQkcMaRxisinjMFMVqZkybdQ==
+  dependencies:
+    playwright-core "1.22.2"
 
 pnp-webpack-plugin@1.6.4:
   version "1.6.4"


### PR DESCRIPTION
# Description

Adds a basic playwright test that loads up the CDN build of the project and does a mocked handshake with Embed. This is focused on resolving TA-1722 (but we might use/adapt later as wider testing strategy).

This is the test in CI:

<img width="874" alt="Screenshot 2022-06-15 at 19 09 59" src="https://user-images.githubusercontent.com/1008377/173895866-768abc45-bb7c-4e76-ab3e-df57a907132c.png">

This is the test with the debugger:

<img width="959" alt="Screenshot 2022-06-15 at 19 12 47" src="https://user-images.githubusercontent.com/1008377/173896295-2843ff5c-c12f-4e5c-8d51-f36acca00768.png">

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [x] I have tested both the react and the CDN versions on local and integration environments
- [x] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
