### PR TITLE
fix: cdn version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,48 +89,48 @@ jobs:
           FOLDER: packages/embed-cdn/lib
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  release:
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.repository_owner == 'gr4vy' && github.ref == 'refs/heads/main'"
-    runs-on: ubuntu-latest
+  # release:
+  #   if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.repository_owner == 'gr4vy' && github.ref == 'refs/heads/main'"
+  #   runs-on: ubuntu-latest
 
-    needs:
-      - test
+  #   needs:
+  #     - test
 
-    strategy:
-      matrix:
-        node-version: [14.x]
+  #   strategy:
+  #     matrix:
+  #       node-version: [14.x]
 
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
 
-      - name: Prepare repository
-        run: git fetch --unshallow --tags
+  #     - name: Prepare repository
+  #       run: git fetch --unshallow --tags
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
+  #     - name: Use Node.js ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
 
-      - name: Cache node modules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: yarn-deps-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            yarn-deps-${{ hashFiles('yarn.lock') }}
+  #     - name: Cache node modules
+  #       uses: actions/cache@v1
+  #       with:
+  #         path: node_modules
+  #         key: yarn-deps-${{ hashFiles('yarn.lock') }}
+  #         restore-keys: |
+  #           yarn-deps-${{ hashFiles('yarn.lock') }}
 
-      - name: Create Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          yarn config set workspaces-experimental true
-          yarn install --frozen-lockfile
-          yarn bootstrap
-          PACKAGE_VERSION=$($GITHUB_WORKSPACE/node_modules/.bin/auto shipit -dq) yarn build
-          yarn release
+  #     - name: Create Release
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  #       run: |
+  #         yarn config set workspaces-experimental true
+  #         yarn install --frozen-lockfile
+  #         yarn bootstrap
+  #         PACKAGE_VERSION=$($GITHUB_WORKSPACE/node_modules/.bin/auto shipit -dq) yarn build
+  #         yarn release
 
   scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,12 @@ jobs:
           yarn test
 
   cdn:
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
-    needs:
-      - test
+    # needs:
+    #   - test
 
     strategy:
       matrix:
@@ -72,9 +72,14 @@ jobs:
             yarn-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Install Node dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           yarn config set workspaces-experimental true
-          yarn setup
+          yarn clean
+          yarn bootstrap
+          PACKAGE_VERSION=$($GITHUB_WORKSPACE/node_modules/.bin/auto shipit -dq) yarn build
 
       - name: Push compiled content
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,48 +89,48 @@ jobs:
           FOLDER: packages/embed-cdn/lib
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # release:
-  #   if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.repository_owner == 'gr4vy' && github.ref == 'refs/heads/main'"
-  #   runs-on: ubuntu-latest
+  release:
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.repository_owner == 'gr4vy' && github.ref == 'refs/heads/main'"
+    runs-on: ubuntu-latest
 
-  #   needs:
-  #     - test
+    needs:
+      - test
 
-  #   strategy:
-  #     matrix:
-  #       node-version: [14.x]
+    strategy:
+      matrix:
+        node-version: [14.x]
 
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
 
-  #     - name: Prepare repository
-  #       run: git fetch --unshallow --tags
+      - name: Prepare repository
+        run: git fetch --unshallow --tags
 
-  #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-  #     - name: Cache node modules
-  #       uses: actions/cache@v1
-  #       with:
-  #         path: node_modules
-  #         key: yarn-deps-${{ hashFiles('yarn.lock') }}
-  #         restore-keys: |
-  #           yarn-deps-${{ hashFiles('yarn.lock') }}
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: yarn-deps-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-deps-${{ hashFiles('yarn.lock') }}
 
-  #     - name: Create Release
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
-  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  #       run: |
-  #         yarn config set workspaces-experimental true
-  #         yarn install --frozen-lockfile
-  #         yarn bootstrap
-  #         PACKAGE_VERSION=$($GITHUB_WORKSPACE/node_modules/.bin/auto shipit -dq) yarn build
-  #         yarn release
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          yarn config set workspaces-experimental true
+          yarn install --frozen-lockfile
+          yarn bootstrap
+          PACKAGE_VERSION=$($GITHUB_WORKSPACE/node_modules/.bin/auto shipit -dq) yarn build
+          yarn release
 
   scan:
     runs-on: ubuntu-latest

--- a/packages/embed-cdn/webpack.prod.js
+++ b/packages/embed-cdn/webpack.prod.js
@@ -1,5 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path')
+const { DefinePlugin } = require('webpack')
+
+const PACKAGE_VERSION = JSON.stringify(process.env.PACKAGE_VERSION || undefined)
+console.log('Building version', PACKAGE_VERSION)
 
 module.exports = {
   mode: 'production',
@@ -28,4 +32,9 @@ module.exports = {
     library: 'gr4vy',
   },
   entry: path.resolve('./src'),
+  plugins: [
+    new DefinePlugin({
+      PACKAGE_VERSION,
+    }),
+  ],
 }


### PR DESCRIPTION
# Description

On the cdn version of Embed, `gr4vy.version` comes out as `undefined` after some latest changes. This PR fixes that.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own changes
- [ ] I have run `yarn lint` to make sure my changes pass all tests
- [ ] I have run `yarn test` to make sure my changes pass all linters
- [ ] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [ ] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
