### PR TITLE
Additional steps to deploy to new storage bucket

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -30,3 +30,10 @@ CVE-2022-25858
 # parse-url - added to get non-code change passing test. Needs fixing.
 CVE-2022-2900
 CVE-2022-3224
+
+# loader-utils - dev dependency
+CVE-2022-37601
+
+# Minimatch dependancy
+# https://avd.aquasec.com/nvd/2022/cve-2022-3517/
+CVE-2022-3517

--- a/cloudbuild/deploy-env.yaml
+++ b/cloudbuild/deploy-env.yaml
@@ -10,6 +10,7 @@ steps:
         'gs://gr4vy-embed-cdn-version-repository/${COMMIT_SHA}',
         'gs://$_ARTIFACT_STORAGE_BUCKET',
       ]
+    waitFor: ['-']
 
   - id: 'Deploy pre-built version'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
@@ -23,6 +24,35 @@ steps:
         'gs://gr4vy-embed-cdn-version-repository/${COMMIT_SHA}',
         'gs://$_ARTIFACT_STORAGE_BUCKET/embed/latest/',
       ]
+    waitFor: ['-']
+
+  # New bucket
+  - id: 'Deploy pre-built version (Deprecated) to new bucket'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
+    entrypoint: gsutil
+    args:
+      [
+        '-m',
+        'rsync',
+        '-r',
+        'gs://gr4vy-embed-cdn-version-repository/${COMMIT_SHA}',
+        'gs://$_NEW_ARTIFACT_STORAGE_BUCKET',
+      ]
+    waitFor: ['-']
+
+  - id: 'Deploy pre-built version to new bucket'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
+    entrypoint: gsutil
+    args:
+      [
+        '-m',
+        'rsync',
+        '-d',
+        '-r',
+        'gs://gr4vy-embed-cdn-version-repository/${COMMIT_SHA}',
+        'gs://$_NEW_ARTIFACT_STORAGE_BUCKET/embed/latest/',
+      ]
+    waitFor: ['-']
 
   - id: 'Invalidate CDN cache'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
@@ -39,11 +69,19 @@ steps:
         fi
         gcloud compute url-maps invalidate-cdn-cache $_URL_MAP_SHARED --host="cdn.$${HOST_DOMAIN}" --path='/embed/latest/*' --async --project $PROJECT_ID
         gcloud compute url-maps invalidate-cdn-cache $_URL_MAP_SHARED --host="cdn.$${HOST_DOMAIN}" --path='/embed.latest.js' --async --project $PROJECT_ID
+    waitFor:
+      [
+        'Deploy pre-built version (Deprecated)',
+        'Deploy pre-built version',
+        'Deploy pre-built version (Deprecated) to new bucket',
+        'Deploy pre-built version to new bucket',
+      ]
 
 substitutions:
   _GR4VY_ID: ${PROJECT_ID%-*}
   _GR4VY_ENV: 'sandbox'
   _ARTIFACT_STORAGE_BUCKET: embed-cdn-${_GR4VY_ENV}-${_GR4VY_ID}-gr4vy-app
+  _NEW_ARTIFACT_STORAGE_BUCKET: ${PROJECT_ID}-cdn-${_GR4VY_ENV}
   _URL_MAP_SHARED: ${_GR4VY_ID}-${_GR4VY_ENV}-url-map
 
 options:


### PR DESCRIPTION
# Description

Google Cloud Storage bucket names need to be globally unique. The current name of the Storage bucket used to host `gr4vy-embed` prevents us from creating a new Gr4vy instance with the same Gr4vy ID because the Gr4vy ID is used in the bucket name. 

A new Storage bucket has been created with a different naming convention and this PR adds an extra deployment step to deploy the `gr4vy-embed` code into this new bucket as well as the old bucket.

Once a migration of traffic to the new bucket has been complete there will be a similar PR to remove the extra step and to only deploy to the new bucket.

Fixes # PE-188

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own changes
- [ ] I have run `yarn lint` to make sure my changes pass all tests
- [ ] I have run `yarn test` to make sure my changes pass all linters
- [ ] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [ ] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
