### PR TITLE
feat: refocus redirect popup

### DIFF
--- a/packages/embed/src/popup/popup.test.ts
+++ b/packages/embed/src/popup/popup.test.ts
@@ -182,8 +182,8 @@ describe('registerSubscriptions', () => {
     subject.approvalCancelled$.next()
   })
 
-  test('restarts approval when lost', () => {
-    subject.approvalUrl$.next('test-url')
+  test('refocus approval when lost', () => {
+    subject.approvalLost$.next()
     subject.mode$.next({
       popup: {
         title: 'Test',
@@ -196,25 +196,18 @@ describe('registerSubscriptions', () => {
     const mockPopup = {
       popup: {
         close: jest.fn(),
+        focus: jest.fn(),
       },
-      stopCallback: jest.fn(),
     } as any
     popup.current = mockPopup
-    let hasApprovalStarted = false
-    let hasApprovalUrlBeenReplayed = false
-    subject.approvalStarted$.subscribe(() => (hasApprovalStarted = true))
-    subject.approvalUrl$.subscribe(() => (hasApprovalUrlBeenReplayed = true))
-    subject.approvalLost$.next()
+    subject.approvalStarted$.next()
 
     jest.runAllTimers()
 
-    expect(mockPopup.stopCallback).toHaveBeenCalled()
-    expect(mockPopup.popup.close).toHaveBeenCalled()
-    expect(hasApprovalStarted).toBeTruthy()
-    expect(hasApprovalUrlBeenReplayed).toBeTruthy()
+    expect(mockPopup.popup.focus).toHaveBeenCalled()
   })
 
-  test('restarts approval without an approval url', () => {
+  test('refocus approval without an approval url', () => {
     subject.approvalUrl$.next(null)
     subject.mode$.next({
       popup: {
@@ -227,7 +220,7 @@ describe('registerSubscriptions', () => {
     })
     const mockPopup = {
       popup: {
-        close: jest.fn(),
+        focus: jest.fn(),
       },
       stopCallback: jest.fn(),
     } as any

--- a/packages/embed/src/popup/popup.ts
+++ b/packages/embed/src/popup/popup.ts
@@ -32,15 +32,7 @@ export const createPopupController = (
 
   subject.approvalLost$.subscribe(() => {
     if (popup.current) {
-      popup.current.stopCallback()
-      popup.current.popup.close()
-      subject.approvalStarted$.next()
-
-      // Check if the approval url already exists
-      const previousApprovalUrl = subject.approvalUrl$.value()
-      if (previousApprovalUrl) {
-        subject.approvalUrl$.next(previousApprovalUrl)
-      }
+      popup.current.popup.focus()
     }
   })
 


### PR DESCRIPTION
# Description

Changes the behaviour of popups so that clicking "Re-open window" on the overlay refocuses an existing popup instead of opening a new one. If there's no existing popup, it will open a new one as usual.

Fixes TA-2948

![2022-11-10 12 15 15](https://user-images.githubusercontent.com/101414321/201077128-03ad7570-dd5d-4b3b-b1f5-c18fc5f8b69b.gif)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [x] I have tested both the react and the CDN versions on local and integration environments
- [x] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
