### PR TITLE
[PE-188] Remove deploy step for old storage bucket

### DIFF
--- a/cloudbuild/deploy-env.yaml
+++ b/cloudbuild/deploy-env.yaml
@@ -26,34 +26,6 @@ steps:
       ]
     waitFor: ['-']
 
-  # New bucket
-  - id: 'Deploy pre-built version (Deprecated) to new bucket'
-    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
-    entrypoint: gsutil
-    args:
-      [
-        '-m',
-        'rsync',
-        '-r',
-        'gs://gr4vy-embed-cdn-version-repository/${COMMIT_SHA}',
-        'gs://$_NEW_ARTIFACT_STORAGE_BUCKET',
-      ]
-    waitFor: ['-']
-
-  - id: 'Deploy pre-built version to new bucket'
-    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
-    entrypoint: gsutil
-    args:
-      [
-        '-m',
-        'rsync',
-        '-d',
-        '-r',
-        'gs://gr4vy-embed-cdn-version-repository/${COMMIT_SHA}',
-        'gs://$_NEW_ARTIFACT_STORAGE_BUCKET/embed/latest/',
-      ]
-    waitFor: ['-']
-
   - id: 'Invalidate CDN cache'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
     entrypoint: bash
@@ -70,18 +42,12 @@ steps:
         gcloud compute url-maps invalidate-cdn-cache $_URL_MAP_SHARED --host="cdn.$${HOST_DOMAIN}" --path='/embed/latest/*' --async --project $PROJECT_ID
         gcloud compute url-maps invalidate-cdn-cache $_URL_MAP_SHARED --host="cdn.$${HOST_DOMAIN}" --path='/embed.latest.js' --async --project $PROJECT_ID
     waitFor:
-      [
-        'Deploy pre-built version (Deprecated)',
-        'Deploy pre-built version',
-        'Deploy pre-built version (Deprecated) to new bucket',
-        'Deploy pre-built version to new bucket',
-      ]
+      ['Deploy pre-built version (Deprecated)', 'Deploy pre-built version']
 
 substitutions:
   _GR4VY_ID: ${PROJECT_ID%-*}
   _GR4VY_ENV: 'sandbox'
-  _ARTIFACT_STORAGE_BUCKET: embed-cdn-${_GR4VY_ENV}-${_GR4VY_ID}-gr4vy-app
-  _NEW_ARTIFACT_STORAGE_BUCKET: ${PROJECT_ID}-cdn-${_GR4VY_ENV}
+  _ARTIFACT_STORAGE_BUCKET: ${PROJECT_ID}-cdn-${_GR4VY_ENV}
   _URL_MAP_SHARED: ${_GR4VY_ID}-${_GR4VY_ENV}-url-map
 
 options:


### PR DESCRIPTION
# Description

A new Storage bucket has been created with a different naming convention and PR https://github.com/gr4vy/gr4vy-embed/pull/109 added an extra deployment step to deploy the `gr4vy-embed` code into this new bucket as well as the old bucket.

Now that our traffic has been migrated to the new bucket this PR removes the extra step and only deploys to the new bucket.

Fixes # PE-188

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own changes
- [ ] I have run `yarn lint` to make sure my changes pass all tests
- [ ] I have run `yarn test` to make sure my changes pass all linters
- [ ] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [ ] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
