### PR TITLE
feat: close popup before unload

### DIFF
--- a/packages/embed/src/overlay/overlay.test.ts
+++ b/packages/embed/src/overlay/overlay.test.ts
@@ -55,4 +55,28 @@ describe('createOverlayController', () => {
 
     expect(overlay.className).toEqual('gr4vy__overlay gr4vy__overlay--visible')
   })
+
+  test('it should close both overlay and popup when a beforeunload event is triggered', () => {
+    let result = false
+    const approvalCancelled = subject.approvalCancelled$.subscribe(
+      () => (result = true)
+    )
+
+    const overlay = document.createElement('div')
+    overlay.className = 'gr4vy__overlay gr4vy__overlay--hidden'
+    createOverlayController(overlay, subject)
+    subject.approvalUrl$.next('https://approval.gr4vy.com')
+
+    jest.runAllTimers()
+
+    expect(overlay.className).toEqual('gr4vy__overlay gr4vy__overlay--visible')
+
+    window.dispatchEvent(new Event('beforeunload'))
+
+    jest.runAllTimers()
+
+    expect(overlay.className).toEqual('gr4vy__overlay gr4vy__overlay--hidden')
+    approvalCancelled.unsubscribe()
+    expect(result).toBe(true)
+  })
 })

--- a/packages/embed/src/overlay/overlay.test.ts
+++ b/packages/embed/src/overlay/overlay.test.ts
@@ -62,6 +62,8 @@ describe('createOverlayController', () => {
       () => (result = true)
     )
 
+    const logSpy = jest.spyOn(console, 'log').mockImplementation()
+
     const overlay = document.createElement('div')
     overlay.className = 'gr4vy__overlay gr4vy__overlay--hidden'
     createOverlayController(overlay, subject)
@@ -71,10 +73,20 @@ describe('createOverlayController', () => {
 
     expect(overlay.className).toEqual('gr4vy__overlay gr4vy__overlay--visible')
 
+    // assuming there's already a beforeunload listener attached that
+    // doesn't stop immediate propagation, so not to conflict with
+    // our own listener call.
+    window.addEventListener('beforeunload', (e) => {
+      e.preventDefault()
+      console.log('Are you leaving?')
+      return (e.returnValue = true)
+    })
+
     window.dispatchEvent(new Event('beforeunload'))
 
     jest.runAllTimers()
 
+    expect(logSpy).toHaveBeenCalledWith('Are you leaving?')
     expect(overlay.className).toEqual('gr4vy__overlay gr4vy__overlay--hidden')
     approvalCancelled.unsubscribe()
     expect(result).toBe(true)

--- a/packages/embed/src/overlay/overlay.ts
+++ b/packages/embed/src/overlay/overlay.ts
@@ -36,13 +36,21 @@ export const createOverlayController = (
 
   element.appendChild(Container)
 
+  const beforeUnloadHandler = (event) => {
+    event.preventDefault()
+    subject.approvalCancelled$.next()
+    return (event.returnValue = true)
+  }
+
   const hide = () => {
     element.className = 'gr4vy__overlay gr4vy__overlay--hidden'
     removeChildren(Container)
+    window.removeEventListener('beforeunload', beforeUnloadHandler)
   }
 
   const show = () => {
     element.className = 'gr4vy__overlay gr4vy__overlay--visible'
+    window.addEventListener('beforeunload', beforeUnloadHandler)
   }
 
   const setMessage = ({ title, link, message, cancel }) => {


### PR DESCRIPTION
# Description

Adds a listener for `beforeunload` once a redirect popup is open, prompting the user to either cancel or leave the site if the window/tab is closed or reloaded. Removes the listener if the popup closes.

Fixes TA-732

![2022-11-10 14 48 38](https://user-images.githubusercontent.com/101414321/201110627-bf8d0e48-b0ad-4678-8ea3-89aa1a395646.gif)

![2022-11-10 14 49 30](https://user-images.githubusercontent.com/101414321/201109966-a1938d5d-272b-4f05-ac99-f34939663b0a.gif)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [x] I have tested both the react and the CDN versions on local and integration environments
- [x] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
