### PR TITLE
chore: add CVE-2022-37603 and CVE-2022-37599 to trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -33,6 +33,8 @@ CVE-2022-3224
 
 # loader-utils - dev dependency
 CVE-2022-37601
+CVE-2022-37599
+CVE-2022-37603
 
 # Minimatch dependancy
 # https://avd.aquasec.com/nvd/2022/cve-2022-3517/


### PR DESCRIPTION
# Description

Add CVE-2022-37603, and CVE-2022-37599 to `.trivyignore`.
