### PR TITLE
fix: trivy vulnerability

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -42,3 +42,6 @@ CVE-2022-3517
 
 # json5
 CVE-2022-46175
+
+# yaml - Dev Dependency (auto, storybook)
+CVE-2023-2251


### PR DESCRIPTION
# Description

Add trivy vulnerability to ignore list
https://github.com/gr4vy/gr4vy-embed/actions/runs/4794544117/jobs/8528041162

I added tags `release` and `patch` as [previous PR](https://github.com/gr4vy/gr4vy-embed/pull/143) was not deployed:
https://console.cloud.google.com/cloud-build/builds;region=global/0d57cdc3-6479-4b9d-8794-1b2e566c0d4e?authuser=1&project=gr4vy-admin

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own changes
- [X] I have run `yarn lint` to make sure my changes pass all tests
- [X] I have run `yarn test` to make sure my changes pass all linters
- [X] I have pulled the latest changes from the upstream `main` branch
- [X] I have tested both the react and the CDN versions on local and integration environments
- [X] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
