### PR TITLE
fix: cannot call gr4vy.setup more than twice when embed is loaded from cdn

### DIFF
--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -297,7 +297,6 @@ export function setup(setupConfig: SetupConfig) {
     window.removeEventListener('message', messageHandler)
     window.removeEventListener('message', apiMessageHandler)
     window.removeEventListener('message', approvalMessageHandler)
-    delete window.gr4vy
   })
 
   return {


### PR DESCRIPTION
# Description

I think the idea of removed line was to clean `gr4vy` completely when `cleanup` is invoked. 
But I think we shouldn't do it because:
1. we run `cleanup` only when user runs `setup` again, so it's part of re-initialisation. It's still there after the first call. 
2. we leave `gr4vy` version available in a window scope anyway
3. there is no possibility for the user to run `setup` again
4. user can do it themself if they want to remove it for some reason

Fixes # [TA-4425](https://gr4vy.atlassian.net/browse/TA-4425)

#### Before:
<img src="https://github.com/gr4vy/gr4vy-embed/assets/685536/4b156489-f8b8-4bee-9918-8c7459d11074" width="300" />

#### After:
<img src="https://github.com/gr4vy/gr4vy-embed/assets/685536/6be8f71e-9cf5-432d-a3e8-52d8aa398b4f" width="300" />


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own changes
- [X] I have run `yarn lint` to make sure my changes pass all tests
- [X] I have run `yarn test` to make sure my changes pass all linters
- [X] I have pulled the latest changes from the upstream `main` branch
- [X] I have tested both the react and the CDN versions on local and integration environments
- [X] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
