### PR TITLE
build: run the `deployer` tool on the cloudbuild network

### DIFF
--- a/cloudbuild/cloudbuild-cdn.yaml
+++ b/cloudbuild/cloudbuild-cdn.yaml
@@ -104,7 +104,7 @@ steps:
           fail=0
           for instance in $${INSTANCES}; do
             echo "Triggering deploy of main branch to $${instance}-sandbox..."
-            docker run --rm -e GITHUB_TOKEN gcr.io/${PROJECT_ID}/deployer:latest deploy --id $${instance} --sandbox --repo ${REPO_NAME} --ref ${COMMIT_SHA} --skip-checks
+            docker run --rm -e GITHUB_TOKEN --network=cloudbuild gcr.io/${PROJECT_ID}/deployer:latest deploy --id $${instance} --sandbox --repo ${REPO_NAME} --ref ${COMMIT_SHA} --skip-checks
             if [ $? -ne 0 ]; then
               fail=1
             fi
@@ -132,7 +132,7 @@ steps:
           fail=0
           for instance in $${INSTANCES}; do
             echo "Triggering deploy of main branch to $${instance}-production..."
-            docker run --rm -e GITHUB_TOKEN gcr.io/${PROJECT_ID}/deployer:latest deploy --id $${instance} --production --repo ${REPO_NAME} --ref ${COMMIT_SHA} --skip-checks
+            docker run --rm -e GITHUB_TOKEN --network=cloudbuild gcr.io/${PROJECT_ID}/deployer:latest deploy --id $${instance} --production --repo ${REPO_NAME} --ref ${COMMIT_SHA} --skip-checks
             if [ $? -ne 0 ]; then
               fail=1
             fi


### PR DESCRIPTION

This change simply attaches the [`deployer`](https://github.com/gr4vy/deployer) container to the cloudbuild network so that we have access to the Cloud Build Service Account credentials for future use.

We're in the process of adding a new features to our [`deployer`](https://github.com/gr4vy/deployer) tool. Some of these new feature will require access to Google Cloud APIs. At the moment the Docker command we use to execute the `deployer` tool doesn't attach the container to the cloudbuild network, which is required to access the Cloud Build service account's credentials:

https://cloud.google.com/build/docs/build-config-file-schema#network
> When Cloud Build runs each build step, it attaches the step's container to a local Docker network named cloudbuild. The cloudbuild network hosts Application Default Credentials (ADC) that Google Cloud services can use to automatically find your credentials. If you're running nested Docker containers and want to expose ADC to an underlying container or using gsutilor gcloud in a docker step, use the --network flag in your docker


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>