### PR TITLE
Cloud Build machineType

### DIFF
--- a/cloudbuild/cloudbuild-cdn.yaml
+++ b/cloudbuild/cloudbuild-cdn.yaml
@@ -159,5 +159,6 @@ availableSecrets:
 options:
   dynamic_substitutions: true
   substitution_option: 'ALLOW_LOOSE'
+  machineType: 'E2_MEDIUM'
 
 timeout: 900s

--- a/cloudbuild/deploy-env.yaml
+++ b/cloudbuild/deploy-env.yaml
@@ -66,3 +66,4 @@ substitutions:
 options:
   dynamic_substitutions: true
   substitution_option: 'ALLOW_LOOSE'
+  machineType: 'E2_MEDIUM'


### PR DESCRIPTION

Google Cloud Build switched from `e2-medium` to `e2-standard-2` machine type as the default instance size for Cloud Build jobs where `machineType` is undefined.

https://cloud.google.com/build/docs/release-notes#September_01_2023

Most of our Cloud Build configs leave the machine type undefined, meaning we’re now using the larger, more expensive instance. We’ve seen our monthly cost for Cloud Build grow from $0.28/minute (Aug) to $0.57/minute (Sept) with no meaningful improvement in build times.

This PR sets `machineType: 'e2-medium'` where it's currently undefined.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>