### PR TITLE
chore(apple-pay): add error message to apple pay session failure

### DIFF
--- a/packages/embed/src/apple-pay/apple-pay.ts
+++ b/packages/embed/src/apple-pay/apple-pay.ts
@@ -44,8 +44,8 @@ export const createApplePayController = (
 
       // start the session
       session.begin()
-    } catch {
-      subjectManager.appleSessionError$.next()
+    } catch (e) {
+      subjectManager.appleSessionError$.next(e?.message)
     }
   })
 

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -284,8 +284,8 @@ export function setup(setupConfig: SetupConfig) {
   subjectManager.appleCancelSession$.subscribe(() =>
     dispatch({ type: 'appleCancelSession' })
   )
-  subjectManager.appleSessionError$.subscribe(() =>
-    dispatch({ type: 'appleSessionError' })
+  subjectManager.appleSessionError$.subscribe((message) =>
+    dispatch({ type: 'appleSessionError', data: message })
   )
   subjectManager.appleCompleteSession$.subscribe(() =>
     dispatch({ type: 'appleCompleteSession' })

--- a/packages/embed/src/subjects.ts
+++ b/packages/embed/src/subjects.ts
@@ -39,7 +39,7 @@ export const createSubjectManager = () => {
     applePayAuthorized$: createSubject<ApplePayJS.ApplePayPaymentToken>(),
     appleCompletePayment$: createSubject<boolean>(),
     appleAbortSession$: createSubject(),
-    appleSessionError$: createSubject(),
+    appleSessionError$: createSubject<string>(),
     appleCancelSession$: createSubject(),
     appleCompleteSession$: createSubject(),
     googlePaySessionStarted$: createSubject(),


### PR DESCRIPTION
# Description

Captures error messages for failing to start an Apple Pay session.

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
