### PR TITLE
Re-add dependabot to handle transitive dependencies vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    # prevent PRs from opening except for security updates (renovatebot takes care of the rest)
+    open-pull-requests-limit: 0
+    reviewers:
+      - 'douglaseggleton'
+    labels:
+      - 'vulnerability'
+      - 'dependencies'


### PR DESCRIPTION
Renovate currently doesn't create PRs for vulnerabilities that only exist in transitive dependencies. There's a `transitiveRemediation` flag that can be used, but it only seems to support npm (or doesn't fully work atm).

The alternative would be to add `:maintainLockFilesMonthly` and let Renovate create a PR to update the lockfile monthly (can be set to weekly too), covering any vulnerability but it sounds messy.

This PR adds back dependabot and tell it to only create those vulnerability PRs, complementing renovate.

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
