### PR TITLE
Add allow-top-navigation to sandbox iframe attribute

### DIFF
--- a/packages/embed/src/frame/frame.test.ts
+++ b/packages/embed/src/frame/frame.test.ts
@@ -25,7 +25,7 @@ describe('createFrameController', () => {
     expect(frameElement.getAttribute('frameBorder')).toEqual('0')
     expect(frameElement.getAttribute('scrolling')).toEqual('no')
     expect(frameElement.getAttribute('sandbox')).toEqual(
-      'allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation'
+      'allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation allow-top-navigation-by-user-activation'
     )
   })
 

--- a/packages/embed/src/frame/frame.ts
+++ b/packages/embed/src/frame/frame.ts
@@ -25,7 +25,7 @@ export const createFrameController = (
   // security
   frame.setAttribute(
     'sandbox',
-    'allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation'
+    'allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation allow-top-navigation-by-user-activation'
   )
 
   subject.frameHeight$.subscribe((height) => {

--- a/packages/embed/src/overlay/overlay.ts
+++ b/packages/embed/src/overlay/overlay.ts
@@ -70,7 +70,7 @@ export const createOverlayController = (
         frameborder="0"
         class="gr4vy__frame"
         allowtransparency="true"
-        sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation"
+        sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation allow-top-navigation-by-user-activation"
       ></iframe>
     `
   }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own changes
- [ ] I have run `yarn lint` to make sure my changes pass all tests
- [ ] I have run `yarn test` to make sure my changes pass all linters
- [ ] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [ ] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.25.2--canary.193.2b45f6c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @gr4vy/embed@2.25.2--canary.193.2b45f6c.0
  npm install @gr4vy/embed-react@2.25.2--canary.193.2b45f6c.0
  # or 
  yarn add @gr4vy/embed@2.25.2--canary.193.2b45f6c.0
  yarn add @gr4vy/embed-react@2.25.2--canary.193.2b45f6c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
