### PR TITLE
feat(embed): honour requiresPopup

### DIFF
--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -161,6 +161,7 @@ export function setup(setupConfig: SetupConfig) {
   > = {
     modeUpdated: subjectManager.mode$.next,
     approvalUrl: subjectManager.approvalUrl$.next,
+    requiresPopup: subjectManager.requiresPopup$.next,
     resize: (data) => subjectManager.frameHeight$.next(data?.frame?.height),
     optionsLoaded: subjectManager.optionsLoaded$.next,
     transactionCreated: subjectManager.transactionCreated$.next,

--- a/packages/embed/src/popup/popup.ts
+++ b/packages/embed/src/popup/popup.ts
@@ -15,6 +15,7 @@ export const createPopupController = (
 ) => {
   subject.approvalStarted$.subscribe(() => {
     const mode = subject.mode$.value()
+    const requiresPopup = subject.requiresPopup$.value()
 
     // clear any existing popup references
     if (popup.current) {
@@ -23,7 +24,7 @@ export const createPopupController = (
       popup.current = undefined
     }
 
-    if (mode?.popup && redirectMode === 'fallback') {
+    if (requiresPopup && mode?.popup && redirectMode === 'fallback') {
       popup.current = openPopup(
         popupFeatures(
           mode.popup?.width || DEFAULT_POPUP_WIDTH,

--- a/packages/embed/src/popup/popup.ts
+++ b/packages/embed/src/popup/popup.ts
@@ -39,9 +39,10 @@ export const createPopupController = (
 
   subject.approvalUrl$.subscribe((url) => {
     const mode = subject.mode$.value()
+    const requiresPopup = subject.requiresPopup$.value()
 
     // redirect behaviour should only be applied to popups
-    if (mode?.popup) {
+    if (requiresPopup && mode?.popup) {
       if (popup.current) {
         redirectPopup(popup.current.popup, url)
       } else {

--- a/packages/embed/src/subjects.ts
+++ b/packages/embed/src/subjects.ts
@@ -21,6 +21,7 @@ export const createSubjectManager = () => {
     approvalCancelled$: createSubject(),
     approvalLost$: createSubject(),
     approvalCompleted$: createSubject(),
+    requiresPopup$: createSubject<boolean>(true),
     frameHeight$: createSubject<number>(0),
     optionsLoaded$: createSubject<boolean>(false),
     formSubmit$: createSubject(),

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -211,6 +211,10 @@ export type Message = { channel: string; data?: unknown } & (
       data: string
     }
   | {
+      type: 'requiresPopup'
+      data: boolean
+    }
+  | {
       type: 'optionsLoaded'
       data: Array<{
         id?: string


### PR DESCRIPTION
# Description

Modify the popup manager to read requiresPopup from the state and not open a popup if redirectPopup is False.

Fixes # TA-6759

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own changes
- [ ] I have run `yarn lint` to make sure my changes pass all tests
- [ ] I have run `yarn test` to make sure my changes pass all linters
- [ ] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [ ] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
