### PR TITLE
feat(apple-pay): pass card network, label & type on transaction create

### DIFF
--- a/packages/embed/src/apple-pay/apple-pay.test.ts
+++ b/packages/embed/src/apple-pay/apple-pay.test.ts
@@ -85,7 +85,7 @@ test('should register an onpaymentmethodselected callback', (done) => {
   const subscription = mockSubjectManager.applePaymentMethodSelected$.subscribe(
     (paymentMethod) => {
       subscription.unsubscribe()
-      expect(paymentMethod).toEqual({ network: 'visa' })
+      expect(paymentMethod).toEqual({ network: 'amex' })
       done()
     }
   )
@@ -94,7 +94,7 @@ test('should register an onpaymentmethodselected callback', (done) => {
 
   // act
   mockAppleSession.onpaymentmethodselected({
-    paymentMethod: { network: 'visa' },
+    paymentMethod: { network: 'amex' },
   })
   jest.runAllTimers()
 })

--- a/packages/embed/src/apple-pay/apple-pay.test.ts
+++ b/packages/embed/src/apple-pay/apple-pay.test.ts
@@ -9,6 +9,7 @@ beforeEach(() => {
   mockAppleSession = {
     onvalidatemerchant: jest.fn(),
     onpaymentauthorized: jest.fn(),
+    onpaymentmethodselected: jest.fn(),
     begin: jest.fn(),
     completeMerchantValidation: jest.fn(),
     completePayment: jest.fn(),
@@ -73,6 +74,28 @@ test('should register an onvalidatemerchant callback', (done) => {
 
   // act
   mockAppleSession.onvalidatemerchant({ validationURL: 'test-url' })
+  jest.runAllTimers()
+})
+
+test('should register an onpaymentmethodselected callback', (done) => {
+  createApplePayController(mockSubjectManager, 3)
+  mockSubjectManager.appleStartSession$.next({ foo: 'bar' } as any)
+
+  // assert
+  const subscription = mockSubjectManager.applePaymentMethodSelected$.subscribe(
+    (paymentMethod) => {
+      subscription.unsubscribe()
+      expect(paymentMethod).toEqual({ network: 'visa' })
+      done()
+    }
+  )
+
+  jest.runAllTimers()
+
+  // act
+  mockAppleSession.onpaymentmethodselected({
+    paymentMethod: { network: 'visa' },
+  })
   jest.runAllTimers()
 })
 

--- a/packages/embed/src/apple-pay/apple-pay.ts
+++ b/packages/embed/src/apple-pay/apple-pay.ts
@@ -33,12 +33,14 @@ export const createApplePayController = (
         subjectManager.appleValidateMerchant$.next(event.validationURL)
       }
 
-      session.onpaymentmethodselected = (event) => {
-        subjectManager.applePaymentMethodSelected$.next(event.paymentMethod)
-      }
+      // session.onpaymentmethodselected = (event) => {
+      //   subjectManager.applePaymentMethodSelected$.next(event.paymentMethod)
+      //   session.completePaymentMethodSelection(100, [])
+      // }
 
       // handle payment authorization
       session.onpaymentauthorized = (event) => {
+        console.log(event.payment)
         subjectManager.applePayAuthorized$.next(event.payment.token)
       }
 

--- a/packages/embed/src/apple-pay/apple-pay.ts
+++ b/packages/embed/src/apple-pay/apple-pay.ts
@@ -12,6 +12,7 @@ export const createApplePayController = (
     | 'appleAbortSession$'
     | 'appleStartSession$'
     | 'appleValidateMerchant$'
+    | 'applePaymentMethodSelected$'
     | 'applePayAuthorized$'
     | 'appleCompleteMerchantValidation$'
     | 'appleCompletePayment$'
@@ -30,6 +31,10 @@ export const createApplePayController = (
       // handle merchant validation
       session.onvalidatemerchant = (event) => {
         subjectManager.appleValidateMerchant$.next(event.validationURL)
+      }
+
+      session.onpaymentmethodselected = (event) => {
+        subjectManager.applePaymentMethodSelected$.next(event.paymentMethod)
       }
 
       // handle payment authorization

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -277,6 +277,9 @@ export function setup(setupConfig: SetupConfig) {
   subjectManager.approvalCancelled$.subscribe(() =>
     dispatch({ type: 'approvalCancelled' })
   )
+  subjectManager.applePaymentMethodSelected$.subscribe((paymentMethod) =>
+    dispatch({ type: 'applePaymentMethodSelected', data: paymentMethod })
+  )
   subjectManager.applePayAuthorized$.subscribe((token) =>
     dispatch({ type: 'applePayAuthorized', data: token })
   )

--- a/packages/embed/src/subjects.ts
+++ b/packages/embed/src/subjects.ts
@@ -35,6 +35,7 @@ export const createSubjectManager = () => {
     transactionCancelled$: createSubject(),
     appleStartSession$: createSubject<ApplePayJS.ApplePayPaymentRequest>(),
     appleValidateMerchant$: createSubject<string>(),
+    applePaymentMethodSelected$: createSubject<ApplePayJS.ApplePayPaymentMethod>(),
     appleCompleteMerchantValidation$: createSubject<any>(),
     applePayAuthorized$: createSubject<ApplePayJS.ApplePayPaymentToken>(),
     appleCompletePayment$: createSubject<boolean>(),


### PR DESCRIPTION
# Description

TA-6838

Adds support for `onpaymentmethodselected` event in Apple Pay SDK.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own changes
- [ ] I have run `yarn lint` to make sure my changes pass all tests
- [ ] I have run `yarn test` to make sure my changes pass all linters
- [ ] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [ ] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
