### PR TITLE
Execute service deployment with a user-defined service account

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,7 +1,8 @@
 # List of vulnerability IDs to be ignored by Trivy.
-
 # Please provide a comment with each vulnerability ID describing why it has been ignored.
 
 # semver - dev dependency (jest)
-
 CVE-2022-25883
+
+# https://github.com/gr4vy/gr4vy-embed/pull/211#issuecomment-2191339336
+CVE-2024-37890

--- a/cloudbuild/deploy-env.yaml
+++ b/cloudbuild/deploy-env.yaml
@@ -67,3 +67,6 @@ options:
   dynamic_substitutions: true
   substitution_option: 'ALLOW_LOOSE'
   machineType: 'E2_MEDIUM'
+
+serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/service-deployment@${PROJECT_ID}.iam.gserviceaccount.com'
+logsBucket: 'gs://${PROJECT_ID}-cloudbuild-logs'


### PR DESCRIPTION

Google Cloud Build automatically selects the default Cloud Build service account to execute builds on your behalf, unless you override this behavior. This default service account may have permissions that are unnecessarily broad.

Google are changing the default behavior for how Cloud Build uses service accounts in new projects. These changes will improve the default security posture going forward.

[Announcement](https://cloud.google.com/build/docs/cloud-build-service-account-updates)


To continue to use Google Cloud Build for Gr4vy service deployments we need to begin specifying a service account to execute the Cloud Build and define the logging options.

[Configure user-specified service accounts](https://cloud.google.com/build/docs/securing-builds/configure-user-specified-service-accounts)

This PR adds the required service account and logging definitions to the cloud build yaml file that's used to deploy this service.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>