### PR TITLE
task: add support for buyer option

### DIFF
--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -36,6 +36,7 @@ export const optionKeys = [
   'externalIdentifier',
   'buyerId',
   'buyerExternalIdentifier',
+  'buyer',
   'environment',
   'store',
   'country',

--- a/packages/embed/src/theme/create-theme.ts
+++ b/packages/embed/src/theme/create-theme.ts
@@ -1,7 +1,4 @@
-type DeepPartial<T> = {
-  // eslint-disable-next-line
-  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
-}
+import { DeepPartial } from 'types'
 
 export type ThemeOptions = {
   borderWidths: Record<string, string>

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -102,8 +102,8 @@ export type BillingAddressFields = {
 export type ShippingDetails = BillingDetails
 
 export type Buyer = {
-  displayName?: string
-  externalIdentifier?: string
+  displayName?: string | null
+  externalIdentifier?: string | null
   billingDetails?: DeepPartial<BillingDetails>
   shippingDetails?: DeepPartial<ShippingDetails>
 }

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -102,6 +102,8 @@ export type BillingAddressFields = {
 export type ShippingDetails = BillingDetails
 
 export type Buyer = {
+  displayName?: string
+  externalIdentifier?: string
   billingDetails?: DeepPartial<BillingDetails>
   shippingDetails?: DeepPartial<ShippingDetails>
 }

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -1,3 +1,8 @@
+export type DeepPartial<T> = {
+  // eslint-disable-next-line
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
+}
+
 export type Config = {
   element: HTMLElement // The element to insert the integration at
   form?: Element // The form to bind the integration to
@@ -10,6 +15,7 @@ export type Config = {
   externalIdentifier?: string // an optional external identifier
   buyerId?: string // the ID of the buyer to associate the payment methods to
   buyerExternalIdentifier?: string // the external ID of the buyer to associate the payment methods to
+  buyer?: Buyer
   environment?: 'production' | 'sandbox'
   store?: 'ask' | boolean
   country: string
@@ -56,6 +62,28 @@ export type Config = {
   optionLabels?: Record<string, string>
 }
 
+export type BillingDetails = {
+  firstName: string
+  lastName: string
+  emailAddress: string
+  phoneNumber: string
+  address: {
+    houseNumberOrName: string
+    line1: string
+    line2: string
+    organization: string
+    city: string
+    postalCode: string
+    country: string
+    state?: string
+    stateCode?: string
+  }
+  taxId: {
+    value: string
+    kind: string
+  }
+}
+
 export type BillingAddressFields = {
   address?: {
     houseNumberOrName?: boolean
@@ -69,6 +97,13 @@ export type BillingAddressFields = {
   firstName?: boolean
   lastName?: boolean
   taxId?: boolean
+}
+
+export type ShippingDetails = BillingDetails
+
+export type Buyer = {
+  billingDetails?: DeepPartial<BillingDetails>
+  shippingDetails?: DeepPartial<ShippingDetails>
 }
 
 export type CustomOption = {

--- a/packages/embed/src/validation.test.ts
+++ b/packages/embed/src/validation.test.ts
@@ -115,6 +115,11 @@ describe('validate', () => {
             firstName: 'John',
             lastName: null,
           },
+          shippingDetails: {
+            address: {
+              country: 'GB',
+            },
+          },
         },
       })
     ).toBeTruthy()
@@ -127,6 +132,14 @@ describe('validate', () => {
             unknown: 'unknown',
           },
           unknown: 'unknown',
+        } as any,
+      })
+    ).toBeFalsy()
+    expect(
+      validate({
+        ...options,
+        buyer: {
+          billingDetails: {},
         } as any,
       })
     ).toBeFalsy()

--- a/packages/embed/src/validation.test.ts
+++ b/packages/embed/src/validation.test.ts
@@ -111,6 +111,8 @@ describe('validate', () => {
       validate({
         ...options,
         buyer: {
+          displayName: 'Test buyer',
+          externalIdentifier: '123',
           billingDetails: {
             firstName: 'John',
             lastName: null,

--- a/packages/embed/src/validation.test.ts
+++ b/packages/embed/src/validation.test.ts
@@ -113,6 +113,7 @@ describe('validate', () => {
         buyer: {
           billingDetails: {
             firstName: 'John',
+            lastName: null,
           },
         },
       })

--- a/packages/embed/src/validation.test.ts
+++ b/packages/embed/src/validation.test.ts
@@ -73,17 +73,17 @@ describe('validate', () => {
         buyerId: '123',
       })
     ).toBeTruthy()
-    // expect(
-    //   validate({
-    //     ...options,
-    //     shippingDetailsId: '123',
-    //     buyer: {
-    //       billingDetails: {
-    //         firstName: 'John',
-    //       },
-    //     },
-    //   })
-    // ).toBeFalsy()
+    expect(
+      validate({
+        ...options,
+        shippingDetailsId: '123',
+        buyer: {
+          billingDetails: {
+            firstName: 'John',
+          },
+        },
+      })
+    ).toBeFalsy()
   })
 
   test('should validate buyer details', () => {

--- a/packages/embed/src/validation.test.ts
+++ b/packages/embed/src/validation.test.ts
@@ -73,6 +73,84 @@ describe('validate', () => {
         buyerId: '123',
       })
     ).toBeTruthy()
+    // expect(
+    //   validate({
+    //     ...options,
+    //     shippingDetailsId: '123',
+    //     buyer: {
+    //       billingDetails: {
+    //         firstName: 'John',
+    //       },
+    //     },
+    //   })
+    // ).toBeFalsy()
+  })
+
+  test('should validate buyer details', () => {
+    jest.spyOn(document, 'querySelector').mockImplementation(() => {
+      return document.createElement('div')
+    })
+
+    const options = {
+      element: `#app`,
+      form: null,
+      amount: 1299,
+      currency: `USD`,
+      iframeHost: `127.0.0.1:8080`,
+      apiHost: `127.0.0.1:3100`,
+      token: `123456`,
+      country: 'US',
+    }
+
+    expect(validate(options)).toBeTruthy()
+    expect(
+      validate({ ...options, buyerExternalIdentifier: '123' })
+    ).toBeTruthy()
+    expect(validate({ ...options, buyerId: '123' })).toBeTruthy()
+    expect(
+      validate({
+        ...options,
+        buyer: {
+          billingDetails: {
+            firstName: 'John',
+          },
+        },
+      })
+    ).toBeTruthy()
+    expect(
+      validate({
+        ...options,
+        buyer: {
+          billingDetails: {
+            firstName: 'John',
+            unknown: 'unknown',
+          },
+          unknown: 'unknown',
+        } as any,
+      })
+    ).toBeFalsy()
+    expect(
+      validate({
+        ...options,
+        buyerExternalIdentifier: '123',
+        buyer: {
+          billingDetails: {
+            firstName: 'John',
+          },
+        },
+      })
+    ).toBeFalsy()
+    expect(
+      validate({
+        ...options,
+        buyerId: '123',
+        buyer: {
+          billingDetails: {
+            firstName: 'John',
+          },
+        },
+      })
+    ).toBeFalsy()
   })
 })
 

--- a/packages/embed/src/validation.ts
+++ b/packages/embed/src/validation.ts
@@ -11,10 +11,21 @@ export const canSkipValidation = ({
   return !required && [undefined, null].includes(value)
 }
 
+// checks if object
+export const isObject = (object?: any) =>
+  object && Object.prototype.toString.call(object) === '[object Object]'
+
+// checks if object is empty
+export const isEmptyObject = (object?: any) =>
+  isObject(object) && Object.keys(object).length === 0
+
 // checks if object adheres to another's schema
-export const isObjectWithSchema = (object?: any, schemaObject?: any) =>
-  Object.entries(object).every(([key, val]) => {
-    if (Object.prototype.toString.call(val) === '[object Object]') {
+export const isObjectWithSchema = (object?: any, schemaObject?: any) => {
+  if (isEmptyObject(object)) {
+    return false
+  }
+  return Object.entries(object).every(([key, val]) => {
+    if (isObject(val)) {
       return isObjectWithSchema(val, schemaObject[key])
     }
     return (
@@ -23,6 +34,7 @@ export const isObjectWithSchema = (object?: any, schemaObject?: any) =>
       (typeof schemaObject[key] === typeof val || val === null)
     )
   })
+}
 
 // Validates a HTML element
 export const validateHTMLElement = ({
@@ -206,28 +218,31 @@ export const validateStore = ({
   return false
 }
 
-const buyerObject: Buyer = {
-  billingDetails: {
-    firstName: '',
-    lastName: '',
-    emailAddress: '',
-    phoneNumber: '',
-    address: {
-      houseNumberOrName: '',
-      line1: '',
-      line2: '',
-      organization: '',
-      city: '',
-      postalCode: '',
-      country: '',
-      state: '',
-      stateCode: '',
-    },
-    taxId: {
-      value: '',
-      kind: '',
-    },
+const buyerDetails = {
+  firstName: '',
+  lastName: '',
+  emailAddress: '',
+  phoneNumber: '',
+  address: {
+    houseNumberOrName: '',
+    line1: '',
+    line2: '',
+    organization: '',
+    city: '',
+    postalCode: '',
+    country: '',
+    state: '',
+    stateCode: '',
   },
+  taxId: {
+    value: '',
+    kind: '',
+  },
+}
+
+const buyerObject: Buyer = {
+  billingDetails: buyerDetails,
+  shippingDetails: buyerDetails,
 }
 
 export const validateBuyer = ({

--- a/packages/embed/src/validation.ts
+++ b/packages/embed/src/validation.ts
@@ -366,6 +366,13 @@ export const validate = (options: SetupConfig) =>
     callback: options.onEvent,
   }) &&
   validateType({
+    argument: 'buyer',
+    value: options.buyer,
+    type: 'object',
+    message: 'must be an object',
+    required: false,
+  }) &&
+  validateType({
     argument: 'environment',
     value: options.environment,
     type: 'string',

--- a/packages/embed/src/validation.ts
+++ b/packages/embed/src/validation.ts
@@ -237,7 +237,6 @@ export const validateBuyer = ({
   required,
   expected,
   callback,
-  buyer = buyerObject,
 }: {
   argument: string
   value: any
@@ -245,9 +244,8 @@ export const validateBuyer = ({
   required?: boolean
   expected: typeof buyerObject
   callback?: (name: string, event: { message: string }) => void
-  buyer?: Buyer
 }) => {
-  const valid = value && isObjectWithSchema(value, buyer)
+  const valid = value && isObjectWithSchema(value, buyerObject)
 
   if (canSkipValidation({ required, value }) || valid) {
     return true

--- a/packages/embed/src/validation.ts
+++ b/packages/embed/src/validation.ts
@@ -241,6 +241,8 @@ const buyerDetails = {
 }
 
 const buyerObject: Buyer = {
+  displayName: '',
+  externalIdentifier: '',
   billingDetails: buyerDetails,
   shippingDetails: buyerDetails,
 }

--- a/packages/embed/src/validation.ts
+++ b/packages/embed/src/validation.ts
@@ -20,7 +20,7 @@ export const isObjectWithSchema = (object?: any, schemaObject?: any) =>
     return (
       schemaObject &&
       key in schemaObject &&
-      typeof schemaObject[key] === typeof val
+      (typeof schemaObject[key] === typeof val || val === null)
     )
   })
 


### PR DESCRIPTION
# Description

As part of the new [Guest Checkout](https://gr4vy.atlassian.net/browse/TA-6580) feature we want to add support for a `buyer` option merchants can use with optional billing and shipping details. This PR does that and also extends validation to make sure integrations don't pass a combination of buyer values or a malformed `buyer` object.

Not using anything fancy like `zod` as I didn't want to add an external library.

**Ticket:** https://gr4vy.atlassian.net/browse/TA-7917

**Screenshots:**

![Screenshot 2024-08-12 at 16 29 10](https://github.com/user-attachments/assets/f2a4fcbf-227f-4221-a225-03f503b0e350)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [x] I have tested both the react and the CDN versions on local and integration environments
- [x] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
