### PR TITLE
chore: enable dev-deps automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,13 @@
     ".devcontainer/**",
     ".github/**",
     ".vscode/**"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "labels": ["dependencies", "internal"],
+      "automerge": true,
+      "semanticCommitScope": "dev-deps"
+    }
   ]
 }


### PR DESCRIPTION
**Description:** Enables automerge for PRs opened by renovatebot, dealing with dev dependencies, so there's less noise for us and will help keeping dependencies up to date. This was enabled for `secure-fields` and have been like that for a while, it works nicely.

@douglaseggleton for that to work, we need also need to make sure we're allowing `renovate` to bypass the approval rules, can you please check that for this repo? I don't see the settings myself (not enough permissions I guess).

![Screenshot 2024-09-05 at 15 10 08](https://github.com/user-attachments/assets/4e1f73f8-2be6-404e-aa39-f6f5999992a3)
