### PR TITLE
chore: remove unused `approve` intent from types and validation

### DIFF
--- a/packages/embed-react/src/index.stories.tsx
+++ b/packages/embed-react/src/index.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<typeof Gr4vyEmbed> = {
       control: { type: 'radio' },
     },
     intent: {
-      options: ['capture', 'approve'],
+      options: ['authorize', 'capture'],
       control: { type: 'radio' },
     },
     environment: {

--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -7,7 +7,7 @@ export type Config = {
   element: HTMLElement // The element to insert the integration at
   form?: Element // The form to bind the integration to
   amount: number // The amount of a given currency to charge
-  intent?: 'authorize' | 'capture' | 'approve' // Defines the intent of this API call. This determines the desired initial state of the transaction.
+  intent?: 'authorize' | 'capture' // Defines the intent of this API call. This determines the desired initial state of the transaction.
   currency: string // Currency to charge the amount in
   token: string // the JWT access token used to authenticate the API
   debug?: boolean // wether to output any debug messages.

--- a/packages/embed/src/validation.test.ts
+++ b/packages/embed/src/validation.test.ts
@@ -608,7 +608,7 @@ describe('validateIntent()', () => {
   })
 
   test('should return true if the intent is valid', () => {
-    ;['authorize', 'capture', 'approve'].forEach((value) => {
+    ;['authorize', 'capture'].forEach((value) => {
       const options = {
         ...defaultOptions,
         value,

--- a/packages/embed/src/validation.ts
+++ b/packages/embed/src/validation.ts
@@ -176,8 +176,7 @@ export const validateIntent = ({
   callback?: (name: string, event: { message: string }) => void
 }): boolean => {
   const valid =
-    typeof value === 'string' &&
-    ['authorize', 'capture', 'approve'].includes(value)
+    typeof value === 'string' && ['authorize', 'capture'].includes(value)
 
   if (canSkipValidation({ required, value }) || valid) {
     return true


### PR DESCRIPTION
# Description

This was removed [a while ago](https://github.com/gr4vy/gr4vy-embed/pull/19) from the docs, but not from the types and validation logic. We don't have it in `core-api`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [x] I have tested both the react and the CDN versions on local and integration environments
- [x] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
