### PR TITLE
Cloud Build tags

### DIFF
--- a/cloudbuild/cloudbuild-cdn.yaml
+++ b/cloudbuild/cloudbuild-cdn.yaml
@@ -155,6 +155,9 @@ availableSecrets:
     - versionName: ${_GITHUB_TOKEN_LOCATION}
       env: 'GITHUB_TOKEN'
 
+tags:
+  - 'gr4vy-build'
+
 options:
   dynamic_substitutions: true
   substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION

Adding tags to the Cloud Build config files to better identify what Cloud Build is being used for and to filer data to visualise build metrics.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>