### PR TITLE
task: add warning log for double submissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: yarn-deps-${{ hashFiles('yarn.lock') }}
@@ -67,7 +67,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: yarn-deps-${{ hashFiles('yarn.lock') }}
@@ -117,7 +117,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: yarn-deps-${{ hashFiles('yarn.lock') }}

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -71,6 +71,9 @@ const cleanup = new Map<string, () => void>()
 // Stores of count of unique embed instances
 let embedId = 0
 
+// Stores timestamp of last submission
+let lastSubmitted = 0
+
 // Load Apple Pay SDK
 const hasLoadedApplePaySdk = loadApplePaySdk()
 
@@ -258,7 +261,19 @@ export function setup(setupConfig: SetupConfig) {
     )
   )
 
-  subjectManager.formSubmit$.subscribe(() => dispatch({ type: 'submitForm' }))
+  subjectManager.formSubmit$.subscribe(() => {
+    dispatch({ type: 'submitForm' })
+
+    const now = Date.now()
+    if (now - lastSubmitted < 250) {
+      warn(
+        "Embed has been submitted more than once in quick succession. If you're using `embed.submit()`, please ensure there's no `form` option set at the same time.",
+        null,
+        { debug: true }
+      )
+    }
+    lastSubmitted = now
+  })
 
   subjectManager.beforeTransactionPending$.subscribe(() => {
     if (config?.onBeforeTransaction) {


### PR DESCRIPTION
# Description

Adds a warning log if Embed is submitted more than once in quick succession so that merchants are aware of potential issues related to a double submission (mainly wallets creating two sessions and throwing `Page already has an active payment session.`)

**Ticket:** https://gr4vy.atlassian.net/browse/TA-10323

**Screenshots:**

![Screenshot 2025-02-25 at 10 56 52](https://github.com/user-attachments/assets/1f501e87-2e8b-4cc3-b615-c5a374018c1b)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [x] I have tested both the react and the CDN versions on local and integration environments
- [x] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
