### PR TITLE
feat: update billingAddressFields type

### DIFF
--- a/packages/embed/src/types.ts
+++ b/packages/embed/src/types.ts
@@ -89,6 +89,7 @@ export type BillingAddressFields = {
   address?: {
     houseNumberOrName?: boolean
     line1?: boolean
+    line2?: boolean
     city?: boolean
     postalCode?: boolean
     state?: boolean


### PR DESCRIPTION
# Description

The `BillingAddressFields` type is missing the optional `address.line2` property, which is going to be supported as part of https://github.com/gr4vy/embed-ui/pull/1252.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own changes
- [ ] I have run `yarn lint` to make sure my changes pass all tests
- [ ] I have run `yarn test` to make sure my changes pass all linters
- [ ] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [ ] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
