### PR TITLE
fix(eaa): frames must have accessible names

### DIFF
--- a/packages/embed/src/overlay/overlay.ts
+++ b/packages/embed/src/overlay/overlay.ts
@@ -67,6 +67,7 @@ export const createOverlayController = (
     Container.innerHTML = html`
       <iframe
         src="${src}"
+        title="Secure payment frame - Gr4vy"
         frameborder="0"
         class="gr4vy__frame"
         allowtransparency="true"


### PR DESCRIPTION
# Description

It adds the `title` attribute to the overlay's iframe.

**Ticket TA-11529**

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [ ] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
