### PR TITLE
chore(deps): upgrade dependencies TA-12136

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "braces": "^3.0.3",
     "css-what": "^5.0.1",
     "path-to-regexp": "^0.1.12",
-    "cookie": "0.7.0"
+    "cookie": "0.7.0",
+    "serialize-javascript": "^6.0.2"
   },
   "engines": {
     "node": ">=20.18.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15032,14 +15032,7 @@ send@0.19.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
-  integrity sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^6.0.2:
+serialize-javascript@^6.0.1, serialize-javascript@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
   integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==


### PR DESCRIPTION
# Description

It fixes a few vulnerabilities reported in `yarn audit` and **Trivy**.

| Library | CVE/Issue | Severity | Instances Fixed |
|---|---|---|---|
| @babel/helpers | CVE-2025-27789 | MODERATE | 30 (across Jest/Babel chains) |
| nanoid | CVE-2024-55565 | MODERATE | 1 |
| axios | CVE-2025-27152 | HIGH | 2 |
| http-proxy-middleware | CVE-2025-32997 | MODERATE | 2 |
| brace-expansion | CVE-2025-5889 | LOW | 36 (across lerna, eslint, Jest chains) |
| serialize-javascript | CVE-2024-11831 | MODERATE | 2 (webpack, Storybook terser-webpack-plugin) |

| yarn audit after | yarn audit before |
|----|---|
| ![CleanShot 2025-07-02 at 22 19 27](https://github.com/user-attachments/assets/fd5b1a90-9a0c-4f98-92e0-23fc2287eb68) | ![CleanShot 2025-07-02 at 19 48 37](https://github.com/user-attachments/assets/02af95a8-e26d-4099-bd11-aeecf3b332c6) |

<sub>Relates to [chore(deps): bump storybook v9 (fix vulnerabilities) #332](https://github.com/gr4vy/gr4vy-embed/pull/332)</sub>

**Ticket [TA-12136](https://gr4vy.atlassian.net/browse/TA-12136)**

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [x] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.


[TA-12136]: https://gr4vy.atlassian.net/browse/TA-12136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ