### PR TITLE
task: expose cardDetailsChanged event to onEvent handler

### DIFF
--- a/packages/embed-react/README.md
+++ b/packages/embed-react/README.md
@@ -210,6 +210,18 @@ Returned when the form encounters an API error.
 }
 ```
 
+#### `cardDetailsChanged`
+
+Returned when the card BIN changes in the form. It contains information on the inputted card, such as the BIN, card type and scheme.
+
+```json
+{
+  "bin": "42424242",
+  "scheme": "visa",
+  "cardType": "debit"
+}
+```
+
 ### Custom Form Submission
 
 Embed will automatically submit the payment form with hidden inputs, this can be prevented using the `onComplete` callback.

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -235,6 +235,18 @@ Returned when the form encounters an API error.
 }
 ```
 
+#### `cardDetailsChanged`
+
+Returned when the card BIN changes in the form. It contains information on the inputted card, such as the BIN, card type and scheme.
+
+```json
+{
+  "bin": "42424242",
+  "scheme": "visa",
+  "cardType": "debit"
+}
+```
+
 ### Custom Form Submission
 
 Embed will automatically submit the payment form with hidden inputs, this can be prevented using the `onComplete` callback.

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -234,6 +234,7 @@ export function setup(setupConfig: SetupConfig) {
           'paymentMethodSelected',
           'transactionCancelled',
           'optionsLoaded',
+          'cardDetailsChanged',
         ].includes(message.type)
       ) {
         config.onEvent?.(message.type, message.data)


### PR DESCRIPTION
# Description

Exposes the new `cardDetailsChanged` event to `onEvent` so merchants can subscribe to it.

Depends on https://github.com/gr4vy/embed-ui/pull/1296

**Ticket:** https://gr4vy.atlassian.net/browse/TA-12022?atlOrigin=eyJpIjoiYTNjYTY3YzE2YzViNDZhN2JkOGFhNjI3MGMxY2E3ZDQiLCJwIjoiaiJ9

**Screenshots:**

![Screenshot 2025-07-08 at 16 48 05](https://github.com/user-attachments/assets/e668336e-7da5-43e5-8db5-c8744cfee869)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [x] I have tested both the react and the CDN versions on local and integration environments
- [x] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
