### PR TITLE
fix: lodash 4.18.0 bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "serialize-javascript": "^7.0.3",
     "on-headers": "1.1.0",
     "tar": "7.5.11",
-    "lodash": "4.18.0",
+    "lodash": "^4.18.1",
     "webpack": "^5.105.4",
     "**/nx/minimatch": "9.0.7",
     "**/nx/yaml": "^2.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10921,10 +10921,10 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4.18.0, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
-  version "4.18.0"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz#dfd726f07ab2e39dd763de28fcf66e395c03e440"
-  integrity sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==
+lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
# Description

We pinned the `lodash` sub-dependency version to `4.18.0` to fix an urgent vulnerability. Turns out, that release was buggy and has since been fixed https://github.com/lodash/lodash/discussions/6174. That bug caused an issue when running the dev app locally:

<img width="2980" height="2870" alt="image (5)" src="https://github.com/user-attachments/assets/7e2e002d-f8b7-40e7-8682-3e8135fef1dc" />

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [ ] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
