### PR TITLE
chore: increase cloudbuild timeout to 30 minutes

### DIFF
--- a/cloudbuild/cloudbuild-cdn.yaml
+++ b/cloudbuild/cloudbuild-cdn.yaml
@@ -166,4 +166,4 @@ options:
 
 logsBucket: 'gs://cloud-build-log-storage'
 
-timeout: 1200s
+timeout: 1800s


### PR DESCRIPTION
# Description

Increases the cloudbuild run timeout to avoid timeout issues during the build https://console.cloud.google.com/cloud-build/builds/504a4327-50b5-49f5-94ae-e24fd83ad003?project=gr4vy-admin. This is more of a band-aid solution while we look into ways to improve the install and build tasks (will tackle that separately).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [ ] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
