### PR TITLE
task: fix uuid vulnerability in webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "**/nx/minimatch": "9.0.7",
     "**/nx/yaml": "^2.8.3",
     "**/@nx/devkit/minimatch": "9.0.7",
+    "**/webpack-dev-server/**/uuid": "^14.0.0",
     "@tootallnate/once": "3.0.1",
     "flatted": "^3.4.0",
     "handlebars": "^4.7.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15149,10 +15149,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^14.0.0, uuid@^8.3.2:
+  version "14.0.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
# Description

Fixes https://github.com/gr4vy/gr4vy-embed/security/dependabot/194

**Ticket:** https://gr4vy.atlassian.net/browse/TA-16394

Tested with the dev apps, didn't see any runtime issues.

**Opus  4.6's analysis:**

```
Resolution is safe. Adding "**/webpack-dev-server/**/uuid": "^14.0.0" will:
  - Install uuid@14 for sockjs's dependency
  - sockjs code never actually executes (ws is default)
  - Even if someone switches to sockjs transport, it would fail on the
  require('uuid') — but that's their problem, and you don't use sockjs transport
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all tests
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch
- [ ] I have tested both the react and the CDN versions on local and integration environments
- [x] I have added the necessary labels to this PR in case a new release needs to be published after merging into `main` (e.g. `release` and `patch`)

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
