### PR TITLE
fix(deps): bump js-yaml to patch CVE-2026-59870

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5205,12 +5205,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jscodeshift@0.15.2:
@@ -8884,7 +8884,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -9057,7 +9057,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -11614,7 +11614,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -11624,7 +11624,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -13717,12 +13717,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -13882,7 +13882,7 @@ snapshots:
       inquirer: 12.9.6(@types/node@20.19.43)
       is-ci: 3.0.1
       jest-diff: 30.4.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       libnpmaccess: 10.0.3
       libnpmpublish: 11.1.2
       load-json-file: 6.2.0


### PR DESCRIPTION
## Summary

- Bumps the two transitive `js-yaml` resolutions to their patched versions, fixing **CVE-2026-59870** (quadratic CPU consumption in `!!omap` resolution, [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj)).
  - `js-yaml@3.15.0 -> 3.15.1` (via `babel-jest > babel-plugin-istanbul > @istanbuljs/load-nyc-config`)
  - `js-yaml@4.3.0 -> 4.3.1` (via `eslint > @eslint/eslintrc`, `lerna > cosmiconfig`, `fork-ts-checker-webpack-plugin > cosmiconfig`)
- Both are dev-only transitive dependencies (build/test tooling), not part of the shipped `@gr4vy/embed*` packages.
- No major bump was needed: both patched versions already satisfy the consumers' existing semver ranges (`^3.13.1` and `^4.3.0`), so `pnpm update js-yaml --recursive` resolved them directly. No `overrides` entry required — the existing `lerna>js-yaml: ^4.3.0` override in `pnpm-workspace.yaml` still applies unchanged and is satisfied by `4.3.1`.

Closes the Dependabot alert: https://github.com/gr4vy/gr4vy-embed/security/dependabot/271

## Test plan

- [x] `pnpm install` — lockfile resolves cleanly
- [x] `pnpm build` — all workspace packages (`embed`, `embed-cdn`, `embed-react`) build successfully
- [x] `pnpm audit` — no more `js-yaml` findings (remaining findings are unrelated, pre-existing `brace-expansion`/`@octokit/*` issues via the `auto` dev tool)
- [x] `npm ls js-yaml` — confirms `3.15.1` and `4.3.1` resolved everywhere, no `3.15.0`/`4.3.0` left

🤖 Generated with [Claude Code](https://claude.com/claude-code)